### PR TITLE
Updated and cleaned Flow properties, Unit groups, Units

### DIFF
--- a/refdata/flow_properties.csv
+++ b/refdata/flow_properties.csv
@@ -1,34 +1,21 @@
 ID,Name,Description,Category,Unit group,Property type
 93a60a56-a3c8-19da-a746-0800200c9a66,Area,,Technical flow properties,Units of area,physical
-93a60a56-a3c8-21da-a746-0800200c9a66,Area*time,,Technical flow properties,Units of area*time,physical
-2d9d802c-002d-4018-a702-d2d46e78625a,Biotic Production (Occ.),,Technical flow properties,Units of mass,physical
-fd9a098b-253e-4f1e-986d-76a775c51722,Biotic Production (Transf.),,Technical flow properties,Units of mass/time,physical
-c0447923-0e60-4b3c-97c2-a86dddd9eea5,Duration,,Technical flow properties,Units of time,physical
+93a60a56-a3c8-21da-a746-0800200c9a66,Area*Time,,Technical flow properties,Units of area*time,physical
 f6811440-ee37-11de-8a39-0800200c9a66,Energy,,Technical flow properties,Units of energy,physical
-e2f7001e-a331-4fc7-8052-c0b9bcf6a05f,Energy/area*time,,Technical flow properties,Units of energy/area*time,physical
-c6984745-192d-416f-9728-d6169ba6267f,Energy/mass*time,,Technical flow properties,Units of energy/mass*time,physical
-a819760a-7651-4579-a786-842f7575df60,Erosion Resistance (Occ.),,Technical flow properties,Units of mass,physical
-27f62f94-3fe1-4df5-9693-9112b832decb,Erosion Resistance (Transf.),,Technical flow properties,Units of mass/time,physical
-838aaa20-0117-11db-92e3-0800200c9a66,Goods transport (mass*distance),,Technical flow properties,Units of mass*length,physical
-93a60a56-a3c8-14da-a746-0800200c9a66,Gross calorific value,,Technical flow properties,Units of energy,physical
-45915a2c-6ee8-45bd-8a46-070a7261558e,Groundwater Replenishment (Occ.),,Technical flow properties,Units of length*area,physical
-58ea2de8-1f31-4248-9b03-18ec5d8db13b,Groundwater Replenishment (Transf.),,Technical flow properties,Units of groundwater replenishment (transf.),physical
-0ddc622a-bc4a-4cf8-a551-9e112864b77f,Items*Length,,Technical flow properties,Units of items*length,physical
+e406dc2a-a672-319e-a9b8-87d4cdd8593a,Guest night,,Technical flow properties,Units of person*time,physical
+0ddc622a-bc4a-4cf8-a551-9e112864b77f,Item transport,,Technical flow properties,Units of number*length,physical
 838aaa23-0117-11db-92e3-0800200c9a66,Length,,Technical flow properties,Units of length,physical
-b7ffb330-95a8-4815-a78c-47fcdee3b768,Length*time,,Technical flow properties,Units of length*time,physical
-fdfecf14-ff8a-4e17-b2b2-f938c4b5cc27,"Market value, bulk prices",,Economic flow properties,Units of currency,economic
+b7ffb330-95a8-4815-a78c-47fcdee3b768,Length*Time,,Technical flow properties,Units of length*time,physical
+fdfecf14-ff8a-4e17-b2b2-f938c4b5cc27,Market value,,Economic flow properties,Units of currency,economic
 93a60a56-a3c8-11da-a746-0800200b9a66,Mass,,Technical flow properties,Units of mass,physical
-4e10f566-0358-489a-8e3a-d687b66c50e6,Mass*time,,Technical flow properties,Units of mass*time,physical
-e0d963f9-d6a4-42a5-90e9-fff8452aa2af,Mechanical Filtration (Occ.),,Technical flow properties,Units of mechanical filtration (occ.),physical
-05e42ba1-dbcd-4dc2-b735-a2f17dd211ae,Mechanical Filtration (Transf.),,Technical flow properties,Units of length*area/time,physical
-93a60a56-a3c8-11da-a746-0800200c9a66,Net calorific value,,Technical flow properties,Units of energy,physical
-93a60a56-a3c8-13da-a746-0800200c9a66,Normal Volume,,Technical flow properties,Units of volume,physical
-01846770-4cfe-4a25-8ad9-919d8d378345,Number of items,,Technical flow properties,Units of items,physical
-8766e10f-9f41-4db0-8173-ad0d002a5b98,Person transport,,Technical flow properties,Units of person transport,physical
-8a9107c2-62a2-4997-95b0-6944c80b774e,Physicochemical Filtration (Occ.),,Technical flow properties,Units of mole*area*time/mass,physical
-ac95ed26-5038-4862-8b82-94f1412875cd,Physicochemical Filtration (Transf.),,Technical flow properties,Units of mole*area/mass,physical
+838aaa20-0117-11db-92e3-0800200c9a66,Mass transport,,Technical flow properties,Units of mass*length,physical
+4e10f566-0358-489a-8e3a-d687b66c50e6,Mass*Time,,Technical flow properties,Units of mass*time,physical
+341fd786-b2ad-4552-a762-5eafcab45dee,Mole,,Technical flow properties,Units of mole,physical
+01846770-4cfe-4a25-8ad9-919d8d378345,Number,,Technical flow properties,Units of number,physical
+8766e10f-9f41-4db0-8173-ad0d002a5b98,Person transport,,Technical flow properties,Units of person*length,physical
+ca160e10-b3f9-4458-9077-0d15b8b31ae5,Power,,Technical flow properties,Units of power,physical
 93a60a56-a3c8-17da-a746-0800200c9a66,Radioactivity,,Technical flow properties,Units of radioactivity,physical
-ecbe0a5d-f397-4b74-993d-32d231e4bcf9,Vehicle transport,,Technical flow properties,Units of vehicle transport,physical
+c0447923-0e60-4b3c-97c2-a86dddd9eea5,Time,,Technical flow properties,Units of time,physical
 93a60a56-a3c8-22da-a746-0800200c9a66,Volume,,Technical flow properties,Units of volume,physical
-64771383-534c-4051-84ca-e195564d5425,Volume*Length,,Technical flow properties,Units of volume*length,physical
-441238a3-ba09-46ec-b35b-c30cfba746d1,Volume*time,,Technical flow properties,Units of volume*time,physical
+64771383-534c-4051-84ca-e195564d5425,Volume transport,,Technical flow properties,Units of volume*length,physical
+441238a3-ba09-46ec-b35b-c30cfba746d1,Volume*Time,,Technical flow properties,Units of volume*time,physical

--- a/refdata/locations.csv
+++ b/refdata/locations.csv
@@ -1,570 +1,473 @@
 ID,Name,Description,Category,Code,Latitude,Longitude
-f0357a3f-154b-32ff-a2bf-f55055457068,Afghanistan,,Country,AF,33.83,66.0
-0d0ac1d0-76ad-307d-8b0e-05f06c746da9,Africa,,Global,RAF,6.42,18.28
-9ebe579b-1c4d-361f-97a7-4d7f59fcb7a6,Akrotiri Sovereign Base Area,,Miscellaneous,Akrotiri Sovereign Base Area,34.63,32.93
-97282b27-8e5d-3186-af8e-57204e4820e5,Albania,,Country,AL,41.14,20.05
-0de7b6a6-1a70-388b-a6e6-eeb3113531a3,Algeria,,Country,DZ,28.14,2.65
-f970e276-7d0c-3e75-876e-a857f92e319b,American Samoa,,Country,AS,-14.25,-170.39
-6b356dcf-86c7-3e74-826f-3ae5725687d3,Americas,,Global,UN-AMERICAS,35.46,-83.09
-523af537-946b-39c4-b836-9ed39ba78605,Andorra,,Country,AD,42.54,1.56
-adac5e63-f80f-3629-a957-3527b25891d3,Angola,,Country,AO,-12.29,17.53
-4921c0e2-d1f6-305a-be1f-9ec2e2041909,Anguilla,,Country,AI,18.22,-63.05
-b2b04af9-f8f3-3b06-a29e-03ac8d3c24ca,Antarctica,,Country,AQ,-80.51,19.97
-4e42f7dd-43ec-3fe1-84de-58610557c5ba,Antigua and Barbuda,,Country,AG,17.28,-61.79
-c582dec9-43ff-3b74-baa0-691df291cea6,Argentina,,Country,AR,-35.37,-65.17
-c04cd38a-eb30-33ad-9f8a-b4e64a0ded7b,Armenia,,Country,AM,40.28,44.93
-b787d22d-9cb0-3342-a58b-f546039117bc,Aruba,,Country,AW,12.51,-69.97
-1c280670-4821-3d48-b168-efc6d6685406,Asia,,Global,RAS,45.29,95.75
-9331c8d7-3b48-3a8f-a4a8-2ea976840ba9,Asia without China,,Cutout,Asia without China,47.17,94.01
-e39deabc-78c0-37a0-a5dd-30a225aa9eec,"Asia, UN Region",,Global,UN-ASIA,32.21,84.6
-8bcc25c9-6aa5-371f-ba76-309077753e67,Australia,,Country,AU,-25.73,134.49
-05b093bc-7b17-3c30-a09d-1c41f13e009a,Australia and New Zealand,,Global,UN-AUSTRALIANZ,-26.37,135.97
-bc388e13-830e-35bd-8be3-d90b027ac5ad,"Australia, Ashmore and Cartier Islands",,Miscellaneous,AU-AS,-12.43,123.58
-3e91fecc-17db-3393-ad8f-0e2c0131053d,"Australia, Australian Capital Territory",,Subdivisions,AU-ACT,-35.49,149.0
-161ff7b5-7ecf-4021-8fff-5def0bf2b27e,"Australia, including overseas territories",,Miscellaneous,"Australia, including overseas territories",-25.73,134.48
-5c0f2c74-2dc9-3fce-b75d-086e7412f81f,"Australia, New South Wales",,Subdivisions,AU-NSW,-32.16,147.01
-4382e0b4-8ddb-3600-bf3d-10de8fabfb86,"Australia, Northern Territory",,Subdivisions,AU-NT,-19.41,133.36
-ceaa2d09-0b6e-398c-98b3-41c15d7db178,"Australia, Queensland",,Subdivisions,AU-QLD,-22.57,144.55
-1494adfb-98f4-3dc3-83b2-10bead2efff7,"Australia, South Australia",,Subdivisions,AU-SA,-30.1,135.82
-5bb22373-e69e-31fe-b00e-0a38a7129c8c,"Australia, Tasmania",,Subdivisions,AU-TAS,-41.96,146.62
-b04ebbb9-1260-3d5b-a16f-5f2a16c4886e,"Australia, Victoria",,Subdivisions,AU-VIC,-36.85,144.3
-2ccce7fd-714d-3ce6-8a5d-909f98c8819f,"Australia, Western Australia",,Subdivisions,AU-WA,-25.46,122.17
-7d0db380-a5b9-3a8b-a1da-0bca241abda1,Austria,,Country,AT,47.58,14.13
-cc8c0a97-c2df-3d73-8aff-160b65aa39e2,Azerbaijan,,Country,AZ,40.28,47.54
-7c9df801-238a-3e28-8ae2-675fd3166a1a,Bahamas (the),,Country,BS,24.22,-76.55
-c08bba7a-0c03-36f1-951e-8474d853ecbf,Bahrain,,Country,BH,26.03,50.56
-cfd7a475-f752-3ef8-95e8-d042c4511dd3,Bajo Nuevo Bank (Petrel Is.),,Miscellaneous,Bajo Nuevo Bank (Petrel Is.),15.79,-79.98
-c419b06b-4c65-39b5-8ff0-5adb3b8424f1,Bangladesh,,Country,BD,23.84,90.24
-21ad0bd8-36b9-3d08-b4cf-640b4c298e7c,Barbados,,Country,BB,13.18,-59.56
-df3f079d-e696-3496-b046-0dcfdbf9bca3,Belarus,,Country,BY,53.53,28.03
-910955a9-07e7-39b8-9ec8-855763108a29,Belgium,,Country,BE,50.63,4.63
-b005ad12-9444-3268-8084-f19bf5e19729,Belize,,Country,BZ,17.2,-88.69
-39b9df3a-0fb3-356d-91a6-3e22260e96ab,Benin,,Country,BJ,9.64,2.32
-08424385-5820-39ca-87f4-66f645784636,Bermuda,,Country,BM,32.31,-64.76
-69206263-69b1-3058-84f5-e3d6f93b5f6e,Bhutan,,Country,BT,27.42,90.4
-ad7532d5-b386-3a40-8fbe-01f9455dca36,Bolivia (Plurinational State of),,Country,BO,-16.7,-64.68
-52196aa5-4f16-34f9-acbf-26439c42c763,"Bonaire, Sint Eustatius and Saba",,Country,BQ,12.66,-67.81
-f70fa700-d983-397a-a43d-b99e1c1bc6a5,"Bonaire, Sint Eustatius and Saba, Saba",,Miscellaneous,BQ-SB,12.66,-67.81
-549bdb57-08be-322f-9b63-882851fbb84e,"Bonaire, Sint Eustatius and Saba, Sint Eustatius",,Miscellaneous,BQ-SE,12.66,-67.81
-07159c47-ee1b-39ae-8fb9-c40d480856c4,Bosnia and Herzegovina,,Country,BA,44.17,17.77
-823355b6-3ab3-3f0a-8e4d-1367e89abd1c,Botswana,,Country,BW,-22.18,23.79
-121aa3ee-4a7d-3b1b-bbc7-60fd0c6de79b,Bouvet Island,,Country,BV,-54.41,3.41
-dc634e20-7282-3fe0-b5be-9a2063390544,Brazil,,Country,BR,-10.78,-53.09
-251a2d08-d031-4589-9318-029ba543abde,"Brazil, Acre",,Subdivisions,BR-AC,-9.29,-70.47
-4c05bd06-d401-45cd-b594-c1eafa0ef95b,"Brazil, Alagoas",,Subdivisions,BR-AL,-9.51,-36.62
-744e0bff-1149-4c95-bea7-74792bc71a21,"Brazil, Amapa",,Subdivisions,BR-AP,1.45,-51.96
-12e2f855-d67d-492c-b59d-12205eeb79ea,"Brazil, Amazonas",,Subdivisions,BR-AM,-4.18,-64.71
-929f1a52-bb4d-4a86-8439-6b01d8813196,"Brazil, Bahia",,Subdivisions,BR-BA,-12.47,-41.7
-dc8836a3-1d91-49ed-b4b7-0482f7ec3eaf,"Brazil, Ceara",,Subdivisions,BR-CE,-5.09,-39.62
-c65371a5-fd9a-4ca9-ae24-c4fde6615445,"Brazil, Distrito Federal",,Subdivisions,BR-DF,-15.77,-47.78
-5d8ac1db-f842-4688-aba1-673c4f07b1dd,"Brazil, Espirito Santo",,Subdivisions,BR-ES,-19.56,-40.66
-1a3d1ef6-b2f8-44b8-b51a-c82dec5f769b,"Brazil, Goias",,Subdivisions,BR-GO,-16.02,-49.6
-6eaa35ce-47d2-4c3d-9079-12adc7ffb375,"Brazil, Maranhao",,Subdivisions,BR-MA,-5.09,-45.28
-64441fa1-0151-47ac-b97a-1fd886b90cae,"Brazil, Mato Grosso",,Subdivisions,BR-MT,-12.96,-55.92
-23baa40a-53e2-4d6c-a61e-a412c2b7aaae,"Brazil, Mato Grosso do Sul",,Subdivisions,BR-MS,-20.33,-54.84
-6e1c02cc-e7fc-4e63-a30e-59cfa5c4d9c1,"Brazil, Mid-western grid",,Electricity,BR-Mid-western grid,-15.3,-54.3
-00e9e1a4-0cf8-4f07-8bad-fd782ed54382,"Brazil, Minas Gerais",,Subdivisions,BR-MG,-18.45,-44.67
-3ece4ff8-55ae-40b2-baea-0d2bf2034fbf,"Brazil, North-eastern grid",,Electricity,BR-North-eastern grid,-8.63,-41.72
-572aa631-8a25-4c16-b437-2ee0672c450d,"Brazil, Northern grid",,Electricity,BR-Northern grid,-4.63,-59.25
-9a205fd8-72f3-423f-b3a7-6b805aaee30b,"Brazil, Para",,Subdivisions,BR-PA,-4.04,-53.13
-717c6f47-2eda-4d1b-8277-83f634ea7c23,"Brazil, Paraiba",,Subdivisions,BR-PB,-7.11,-36.82
-3b2c2140-c25c-47c5-876d-78e5dc82f066,"Brazil, Parana",,Subdivisions,BR-PR,-24.63,-51.63
-a64ba70d-b110-4f81-b415-299c0c193faa,"Brazil, Pernambuco",,Subdivisions,BR-PE,-8.33,-37.99
-70c9eee0-7dc4-4e2f-8dcc-f6bc4358ead9,"Brazil, Piaui",,Subdivisions,BR-PI,-7.41,-42.98
-862723a2-2563-490a-9b7a-7206cb46fcb1,"Brazil, Rio de Janeiro",,Subdivisions,BR-RJ,-22.19,-42.66
-8cd18b82-fdd2-4cf9-87c8-33e125b675f4,"Brazil, Rio Grande do Norte",,Subdivisions,BR-RN,-5.83,-36.67
-2248c6cf-f68d-4dac-85bb-fac7e80064f6,"Brazil, Rio Grande do Sul",,Subdivisions,BR-RS,-29.73,-53.31
-d9497730-f613-4d31-aab2-1d82add2d1bc,"Brazil, Rondonia",,Subdivisions,BR-RO,-10.91,-62.84
-2a7e9ed2-4de5-4b28-9b4e-b12c50a1ed53,"Brazil, Roraima",,Subdivisions,BR-RR,2.06,-61.4
-4645f771-3596-4c42-ba0f-822d1ce2fb72,"Brazil, Santa Catarina",,Subdivisions,BR-SC,-27.24,-50.48
-a7ba1868-375a-4d62-9048-bdf2136447c4,"Brazil, Sao Paulo",,Subdivisions,BR-SP,-22.26,-48.72
-17a40e27-7f28-48c3-892d-6121e748ed01,"Brazil, Sergipe",,Subdivisions,BR-SE,-10.57,-37.44
-7e6d7407-6a88-50d1-8f56-eb53f1c12102,"Brazil, South-eastern and Mid-western grid",,Electricity,"Brazil, South-eastern and Mid-western grid",-16.94,-51.03
-df7d08ae-6f20-4095-96e6-3d9cc6f49263,"Brazil, South-eastern grid",,Electricity,BR-South-eastern grid,-19.72,-45.48
-dd2330a8-30dc-4af9-bb3a-d2d2bf404dde,"Brazil, Southern grid",,Electricity,BR-Southern grid,-27.57,-52.26
-54e71d4b-1d1f-473d-91db-15d40c496a6d,"Brazil, Tocantins",,Subdivisions,BR-TO,-10.14,-48.32
-f98ed07a-4d5f-30f7-9e14-10d905f1477f,British Indian Ocean Territory (the),,Country,IO,-7.14,72.29
-4e58188f-f528-3ea1-aec7-38fffc0e118d,Brunei Darussalam,,Country,BN,4.51,114.72
-5523c88d-d347-31b7-8c61-7f632b7efdb7,Bulgaria,,Country,BG,42.76,25.21
-c9f9d7dd-806c-3412-a041-837a80f47c64,Burkina Faso,,Country,BF,12.26,-1.75
-99d4fb3d-b156-3c87-9a2c-dfc0158b37c3,Burundi,,Country,BI,-3.35,29.87
-de3ec0aa-2234-3a1e-bee2-75bbc715c6c9,Cabo Verde,,Country,CV,15.94,-23.97
-fa46ec0b-4924-38c2-994a-53ef61b94039,Cambodia,,Country,KH,12.71,104.9
-820eb5b6-96ea-3a65-bc0d-b1e258dc7d81,Cameroon,,Country,CM,5.69,12.73
-5435c69e-d3bc-35b2-a4d5-80e393e373d3,Canada,,Country,CA,61.37,-98.29
-546c1bd3-1f98-3d06-b407-1a7319f0ca71,Canada without Alberta,,Cutout,Canada without Alberta,61.74,-97.34
-9a0db1a8-1866-3aaa-9f25-881d425e2981,Canada without Alberta and Quebec,,Cutout,Canada without Alberta and Quebec,62.96,-101.08
-042dd99e-b0ff-3653-814e-445ca0093427,Canada without Quebec,,Cutout,Canada without Quebec,62.47,-101.92
-888ae6c0-9317-341c-86a4-6bfdf09b72fa,"Canada, Alberta",,Subdivisions,CA-AB,55.16,-114.5
-391d04b7-aa3e-3b93-9d1f-4d14740ef5f7,"Canada, British Columbia",,Subdivisions,CA-BC,54.76,-124.75
-e2494db3-71b1-310e-bc75-5ff220d01c47,"Canada, Manitoba",,Subdivisions,CA-MB,54.92,-97.43
-aa44e6fb-24ea-30f5-9463-91346594e4e8,"Canada, New Brunswick",,Subdivisions,CA-NB,46.62,-66.37
-2d3a62fe-4d77-3861-9a5d-b0ba1452a7bc,"Canada, Newfoundland and Labrador",,Subdivisions,CA-NL,52.87,-60.51
-bef33c35-d56a-3154-a9e2-b20a11d7580f,"Canada, Northwest Territories",,Subdivisions,CA-NT,66.35,-119.01
-c4f314d4-d365-310d-89a0-42946be99544,"Canada, Nova Scotia",,Subdivisions,CA-NS,45.15,-63.31
-c290d478-7431-3b6d-8372-325203b55c32,"Canada, Nunavut",,Subdivisions,CA-NU,71.02,-88.89
-5bd185b8-bc04-31d4-8307-5955dc838694,"Canada, Ontario",,Subdivisions,CA-ON,50.06,-85.82
-24213e9e-14b7-3f9c-be7d-189643518a9d,"Canada, Prince Edward Island",,Subdivisions,CA-PE,46.4,-63.24
-868a66d1-7428-4ba2-9125-253b07afc119,"Canada, Quebec",,Subdivisions,CA-QC,53.38,-71.78
-6108d9a8-6ab3-3a57-b470-a194c15a1d16,"Canada, Saskatchewan",,Subdivisions,CA-SK,54.41,-105.89
-11c42ab9-2538-3eb1-b665-6076cee71221,"Canada, Yukon",,Subdivisions,CA-YT,63.63,-135.51
-e7d76f14-42a7-3fc0-bec2-21a3f18683d1,Canary Islands,,Miscellaneous,ES-CN,28.33,-15.67
-288ea1e1-79de-3bc8-8a29-958f9857d9d1,Caribbean,,Global,UN-CARIBBEAN,20.15,-74.9
-9e854e58-6592-3fe3-961f-e89d56220808,Cayman Islands (the),,Country,KY,19.42,-80.87
-4e29342d-9904-364e-9e25-fd3b92558e2f,Central African Republic (the),,Country,CF,6.56,20.46
-41f3dc5d-9734-339d-86ad-47fe2970dfe0,Central America,,Global,UN-CAMERICA,21.81,-99.25
-8b6ba8a9-5220-3f57-8627-6e64a0f1cb40,Central and Eastern Europe,,Global,EEU,0.0,0.0
-f60425bb-5d9d-361c-8365-b042007676c0,Central Asia,,Global,CAS,45.91,66.46
-f114427f-29d0-3a63-9781-f1cc950e138e,Centrally Planned Asia and China,,Global,CPA,0.0,0.0
-626726e6-0bd1-315f-b671-9a308a25b798,Chad,,Country,TD,15.33,18.64
-161747ec-4dc9-355f-9760-195593742232,Chile,,Country,CL,-37.74,-71.36
-7efdfc94-655a-35dc-aa3e-c85e9bb703fa,China,,Country,CN,36.55,103.83
-5874165e-031e-4e85-ab69-8c2ae6a1a970,China without Inner Mongol,,Cutout,China without Inner Mongol,35.38,102.25
-b89fbb5e-5b12-3fbf-84e0-dde2a1af83e7,"China, Anhui (安徽)",,Subdivisions,CN-AH,31.82,117.22
-0c3eee87-5877-3e08-bafd-45af750ca0b8,"China, Beijing (北京)",,Subdivisions,CN-BJ,40.17,116.4
-f6298475-5b7f-5c28-9885-2338946a6cd6,"China, Central Grid",,Electricity,CN-CCG,30.58,107.94
-4c4a60a5-a0d5-369e-ad35-c23714845ace,"China, China Southern Power Grid",,Electricity,CN-CSG,24.56,106.46
-560cccf0-0b87-306f-bffd-5836e1175a7a,"China, Chongqing (重庆)",,Subdivisions,CN-CQ,30.05,107.85
-b6ec5424-a43b-5e34-a8ca-f35abb031049,"China, East Grid",,Electricity,CN-ECGC,29.43,117.82
-f15daa22-c911-3f89-ba04-2f020804afd5,"China, Fujian (福建)",,Subdivisions,CN-FJ,26.07,117.97
-10a33d7b-6e2e-3aa5-8dee-a126f06ae6c1,"China, Gansu (甘肃)",,Subdivisions,CN-GS,37.82,100.92
-e0da2e3f-1c41-368e-b7f1-d1aa54166975,"China, Guangdong (广东)",,Subdivisions,CN-GD,23.35,113.42
-e66b9cb6-fca6-3058-b3fc-ab1eea7e2162,"China, Guangxi (广西壮族自治区)",,Subdivisions,CN-GX,23.83,108.77
-a0e80568-b717-32ee-ac16-0fb0030b51cd,"China, Guizhou (贵州)",,Subdivisions,CN-GZ,26.81,106.87
-c7439785-e07d-3db1-a531-12b8a73fb9c2,"China, Hainan (海南)",,Subdivisions,CN-HI,19.19,109.74
-8f697344-3337-3a4d-a98b-fb261935fd20,"China, Hebei (河北)",,Subdivisions,CN-HE,39.55,116.12
-e40e7f95-3d17-3bfe-bd65-a885f2088578,"China, Heilongjiang (黑龙江省)",,Subdivisions,CN-HL,47.87,127.74
-37c4a9b5-5f7d-3238-bb72-4623cde79d2a,"China, Henan (河南)",,Subdivisions,CN-HA,33.88,113.6
-60418cbc-6847-3b06-a830-253aa9bd9dba,"China, Hubei (湖北)",,Subdivisions,CN-HB,30.97,112.26
-7bbc9d94-7ed7-3d7a-9953-f020aa8fa299,"China, Hunan (湖南)",,Subdivisions,CN-HN,27.61,111.69
-1e9be3c3-b260-37d5-8199-be20ff6cc65f,"China, Jiangsu (江苏)",,Subdivisions,CN-JS,32.97,119.44
-8f93bdbf-02dd-37f2-9c94-15b7adb0520c,"China, Jiangxi (江西)",,Subdivisions,CN-JX,27.61,115.71
-5cb7fbc5-6a92-345e-9b8c-205b7d56e247,"China, Jilin (吉林)",,Subdivisions,CN-JL,43.67,126.17
-b6c0a73a-ad7d-352e-a96f-0e22769d89d5,"China, Liaoning (辽宁)",,Subdivisions,CN-LN,41.3,122.61
-94f8eaf5-2a69-3408-a868-564ba00a53e9,"China, Nei Mongol (内蒙古自治区)",,Subdivisions,CN-NM,44.08,113.9
-fc88ecd5-d3d6-3669-a708-4b9a86e8907d,"China, Ningxia (宁夏回族自治区)",,Subdivisions,CN-NX,37.26,106.16
-ae30ab76-bfa2-59fb-bccc-1ad0246cd7b3,"China, North Grid",,Electricity,CN-NCGC,42.29,114.41
-f0894a96-367f-5327-bc91-e156fdb6a5c7,"China, Northeast Grid",,Electricity,CN-NECG,45.76,126.49
-fa7f6c22-bd54-58c5-a8f0-0939ace8b856,"China, Northwest Grid",,Electricity,CN-NWG,39.0,91.62
-8091cd9d-b8ec-3623-a5a2-5b61ea85eb98,"China, Qinghai (青海)",,Subdivisions,CN-QH,35.74,96.0
-442e473c-81d4-34e6-a31e-a13d33c939af,"China, Shaanxi (陕西)",,Subdivisions,CN-SN,35.18,108.86
-21f95e96-39a6-3597-9376-f920757c6fb3,"China, Shandong (山东)",,Subdivisions,CN-SD,36.35,118.15
-26f19341-0269-3662-9c33-6561ad91237f,"China, Shanghai (上海)",,Subdivisions,CN-SH,31.18,121.44
-61ca6a75-802d-39f2-b7b3-09767d6389e0,"China, Shanxi (山西)",,Subdivisions,CN-SX,37.57,112.28
-3ea7c4c6-7057-3b39-96e1-a3251dda63b2,"China, Sichuan (四川)",,Subdivisions,CN-SC,30.61,102.7
-094ba255-b84b-5fbd-8c8a-75547f362075,"China, Southwest Grid",,Electricity,CN-SWG,31.68,88.11
-6515e168-6762-351f-b146-9deb97414906,"China, State Grid Corporation of China",,Electricity,CN-SGCC,37.8,103.55
-267b1b52-9830-3ddd-bce9-0be0b80a70ec,"China, Tianjin (天津)",,Subdivisions,CN-TJ,39.29,117.31
-524dc282-e858-3e44-b59c-05a258bde0bd,"China, Xinjiang (新疆维吾尔自治区)",,Subdivisions,CN-XJ,41.09,85.18
-7b09132e-4f69-3321-b69f-fbaafccb926a,"China, Xizang (西藏自治区)",,Subdivisions,CN-XZ,31.68,88.11
-9825d889-e0ea-346a-8a60-09d9de7ad000,"China, Yunnan (云南)",,Subdivisions,CN-YN,24.97,101.47
-e22dbdd9-06f5-3598-accc-59c8ff842535,"China, Zhejiang (浙江)",,Subdivisions,CN-ZJ,29.17,120.07
-0bdff809-5c8b-31b3-8775-bf35547a1317,Christmas Island,,Country,CX,-10.49,105.66
-8c37ce4b-665f-30ac-abb4-0fd2a3c43b04,Churchill Falls Generating Station,,Miscellaneous,Churchill Falls Generating Station,53.52,-63.99
-8f775bae-e910-3a54-8541-f4a49f87b2f2,Clipperton Island,,Miscellaneous,FR-CP,10.29,-109.22
-e0323a90-39ad-3297-8bf5-b49550572c7c,Cocos (Keeling) Islands (the),,Country,CC,-12.17,96.86
-ab6c0400-6660-3ef2-919d-512b21dce9ab,Colombia,,Country,CO,3.9,-73.08
-f9180cb9-286c-39c4-b3a6-c793798b9ddf,Commonwealth of Independent States,,Miscellaneous,CIS,59.95,92.26
-9b05de73-d43f-3c4e-8111-0c6bcc5312bc,Comoros (the),,Country,KM,-11.88,43.68
-6865aeb3-a9ed-38f9-a79e-c454b259e5d0,Congo (the Democratic Republic of the),,Country,CD,-2.87,23.64
-6e9cf3ee-f65d-3697-b96c-f33f27eb0f57,Congo (the),,Country,CG,-0.83,15.21
-d5a5b3dd-1ccb-30d3-8360-f0c068fd43fc,Cook Islands (the),,Country,CK,-19.81,-158.79
-6bb17796-0cff-3545-9414-6bd0821b4560,Coral Sea Islands,,Miscellaneous,AU-CR,-18.52,151.27
-324d8a1d-3f81-3730-9509-9a48cee0c5b6,Costa Rica,,Country,CR,9.97,-84.19
-adab7b70-1f23-3b82-814c-8506d3dc784e,Croatia,,Country,HR,45.06,16.39
-a4dbfd6a-ef3b-3045-be61-aa0146debdf8,Cuba,,Country,CU,21.62,-79.03
-0707ba09-2e91-360b-b05c-326e6a353593,Curaçao,,Country,CW,12.19,-68.97
-471c1f3f-c1dd-3bb8-8d03-41b03e4be59e,Cyprus,,Country,CY,34.91,32.98
-b40feb9f-0afa-3eab-9c03-5085ecbbb908,Cyprus No Mans Area,,Miscellaneous,Cyprus No Mans Area,35.1,33.25
-9c049173-fad5-34f8-9c68-231237df85b8,Czechia,,Country,CZ,49.73,15.31
-35ea51ba-f1fe-3f01-82ad-5f950855dde0,Côte d'Ivoire,,Country,CI,7.62,-5.56
-0ecbf942-6bcf-3d9a-886d-ed5fc8c4eca8,Denmark,,Country,DK,55.96,10.05
-2a552811-5dc6-3462-a113-dda562233bd7,Dhekelia Sovereign Base Area,,Miscellaneous,Dhekelia Sovereign Base Area,35.01,33.79
-64ca6097-2a6e-3926-91c4-b9d31080c687,Djibouti,,Country,DJ,11.75,42.56
-608e7dc1-16de-3157-b060-12b4f0be82ac,Dominica,,Country,DM,15.43,-61.35
-d4579b26-88d6-3523-9f40-2f6b4b43bcbf,Dominican Republic (the),,Country,DO,18.89,-70.49
-e110324f-3d3c-3394-a6f8-f87e742dcaa4,Eastern Africa,,Global,UN-EAFRICA,-4.37,36.48
-95b09ece-0ccc-3fa4-89f0-ef29d63c6dbe,Eastern Asia,,Global,UN-EASIA,38.17,105.29
-db28a51a-61d7-3b0b-bb5c-a1c0a25db72e,Eastern Europe,,Global,UN-EEUROPE,61.13,91.92
-2f53e6f3-f2ac-3041-a4e0-737e58c45321,Ecuador,,Country,EC,-1.42,-78.77
-2a6a84e9-e444-31af-bd75-cc19ce28be37,Egypt,,Country,EG,26.49,29.86
-74354112-1c12-3113-af80-7d1582c74bea,El Salvador,,Country,SV,13.73,-88.87
-b84a1ed8-db3d-3bf3-b8f4-9becdea153b2,Equatorial Guinea,,Country,GQ,1.7,10.33
-818f9c45-cfa3-3eef-b277-ef38bcbe9910,Eritrea,,Country,ER,15.35,38.85
-08a4415e-9d59-3ff9-a003-0b921d42b91e,Estonia,,Country,EE,58.67,25.53
-7dabf5c1-98b0-3ab2-aaa4-2bb03a113e55,Eswatini,,Country,SZ,-26.56,31.48
-4de1b7a4-dc53-34a8-8c25-ffb7cdb580ee,Ethiopia,,Country,ET,8.62,39.6
-9813077a-1292-3b9e-9da5-bd55fa33ecb6,EU Associated Countries 2005,,Miscellaneous,EU-AC2005,0.0,0.0
-b3c26978-fa5b-3e96-998d-3d5eb0cce441,EU Associated Countries 2007,,Miscellaneous,EU-AC2007,0.0,0.0
-1a88a0a3-7c7f-3bac-96c8-988fe871a18d,EU Candidate Countries 2005,,Miscellaneous,EC-CC2005,0.0,0.0
-0273c379-31a2-34e3-9d4a-351b4c0f4ef2,EU Candidate Countries 2007,,Miscellaneous,EC-CC2007,0.0,0.0
-1981f919-7ad2-31d5-8748-b520285f6323,EU New Member Countries 2004,,Miscellaneous,EU-NMC2004,0.0,0.0
-c1717bc2-161f-3b18-90d6-80e24878d689,EU-15 European Union,,Miscellaneous,EU15,0.0,0.0
-70262596-fdf2-327d-b787-12fb738a9270,EU-25 European Union,,Miscellaneous,EU25,0.0,0.0
-80e68c50-5cf3-3f11-b809-f8cfbd9a4b17,EU-25 European Union and Candidate Countries 2005,,Miscellaneous,EU25-CC2005,0.0,0.0
-d5ef8373-2ea8-3c9b-9fb5-4f8cb68a9714,EU-25 European Union and Candidate Countries 2005 and Associated Countries 2005,,Miscellaneous,EU25-CC2005-AC2005,0.0,0.0
-5c7f219e-57db-3579-a019-27fb8995651b,EU-27 European Union,,Miscellaneous,EU27,0.0,0.0
-322eb489-99c8-380b-8870-87c8d2e958a2,EU-27 European Union and Candidate Countries 2007,,Miscellaneous,EU27-CC2007,0.0,0.0
-aef4c4e7-71b3-3811-876f-5a31fbf8eb0e,EU-27 European Union and Candidate Countries 2007 and Associated Countries 2007,,Miscellaneous,EU27-CC2007-AC2007,0.0,0.0
-d66c264e-1dbd-33e6-911d-3ffc70908e8e,Europe,,Global,RER,55.89,28.11
-67c114d5-d361-4466-a5e7-fc21c498a254,Europe without Austria,,Cutout,Europe without Austria,55.95,28.21
-06e2458b-3178-3438-b3f4-84051244c27d,"Europe without Austria, Belgium, France, Germany, Italy, Liechtenstein, Monaco, San Marino, Switzerland, and the Vatican",,Cutout,"Europe without Austria, Belgium, France, Germany, Italy, Liechtenstein, Monaco, San Marino, Switzerland, and the Vatican",56.99,30.72
-5d5718f2-ee74-462a-888c-be4d534ef542,Europe without Germany and Switzerland,,Cutout,Europe without Germany and Switzerland,56.08,28.77
-ae85cec6-cc61-4a0d-a322-5fb10b6b4ece,"Europe without Germany, Netherlands, Norway",,Cutout,"Europe without Germany, Netherlands, Norway",55.72,29.53
-8bd484ff-ec4e-45c6-9f61-e211a872a4ff,"Europe without Germany, Netherlands, Norway, Russia",,Cutout,"Europe without Germany, Netherlands, Norway, Russia",52.47,14.88
-5c322a16-89ab-48d4-b1a2-fec5759774a3,"Europe without Germany, Netherlands, Russia",,Cutout,"Europe without Germany, Netherlands, Russia",53.42,14.82
-e6a1bb9b-c1f3-49ed-a64b-87d488244ef9,Europe without Russia,,Cutout,Europe without Russia,53.28,14.51
-817ed804-f0ed-3175-b39d-7576a1c242b1,Europe without Switzerland,,Cutout,Europe without Switzerland,55.92,28.18
-f4f87f1d-101c-4b43-b2de-f646734ae9fe,Europe without Switzerland and Austria,,Cutout,Europe without Switzerland and Austria,55.98,28.28
-6a1e0054-4990-4d43-b7e4-e3d9a595a275,Europe without Switzerland and France,,Cutout,Europe without Switzerland and France,56.36,29.39
-b380c952-746f-3cf9-89ae-d6562c7ee132,"Europe, Baltic System Operator",,Electricity,BALTSO,56.8,24.71
-35c302ef-c91c-31e9-a4e6-490bbe01a06f,"Europe, Central European Power Association",,Electricity,CENTREL,50.67,18.81
-c93762d2-a7a3-335c-81c2-fa0be65506df,"Europe, Europe with NORDEL",,Electricity,Europe with NORDEL,54.06,29.67
-a2d4e588-e0d1-11de-823b-0019e336be3a,"Europe, Europe without NORDEL",,Electricity,Europe without NORDEL,54.44,30.4
-8ebf61e1-cf59-357c-b93d-225d0ccb7181,"Europe, European Network of Transmission Systems Operators for Electricity",,Electricity,ENTSO-E,53.78,12.18
-4205164e-e2e5-30d6-98fb-7657af40aed6,"Europe, Nordic Countries Power Association",,Electricity,NORDEL,63.75,18.86
-e743b51e-41f8-3369-9418-34177c8f34e7,"Europe, UCTE without France",,Electricity,UCTE without France,45.99,12.44
-cdba052d-e53c-3173-b857-3d555fad2c16,"Europe, UCTE without Germany",,Electricity,UCTE without Germany,45.41,10.85
-8dc6a685-44c9-3a1c-b937-78a6de2d9830,"Europe, UCTE without Germany and France",,Electricity,UCTE without Germany and France,45.14,12.79
-1e11ad8e-d46d-368b-9ef5-a43e99dec543,"Europe, UN Region",,Global,UN-EUROPE,60.1,78.92
-b633c174-f67b-3819-a2a4-ef89f2d5b8cb,"Europe, Union for the Co-ordination of Transmission of Electricity",,Electricity,UCTE,46.09,10.79
-73ecfbb1-f6be-3c1e-b05a-aca2cb5b216d,"Europe, without Russia and Türkiye",,Cutout,Europe without Russia and Türkiye,53.28,14.51
-ef1cb6e7-2d14-3b18-8cc2-41037203f60b,Falkland Islands (the),,Country,FK,-51.73,-59.37
-eed80702-4939-3808-883f-0031a56e9872,Faroe Islands (the),,Country,FO,62.07,-6.87
-6fac3ab6-03bb-3fb4-ae42-77786393194c,Fiji,,Country,FJ,-17.44,163.4
-75778bf8-fde7-366d-816b-0089e7b8b793,Finland,,Country,FI,64.49,26.27
-190aeb66-f132-3e93-995a-70e36f3431c5,Former Soviet Union,,Miscellaneous,Former Soviet Union,59.95,92.26
-82a9e4d2-6595-387a-b6e4-42391d8c5bba,France,,Country,FR,46.55,2.54
-c4f57fe2-5b64-3193-8cfd-d118f11e9024,"France, including overseas territories",,Miscellaneous,"France, including overseas territories",41.05,-1.86
-e5bb2379-7bfe-3314-a3db-43d07dbd6a74,French Guiana,,Country,GF,3.92,-53.24
-7287aa2c-53d0-3440-9a9d-b5614937e36f,French Polynesia,,Country,PF,-15.18,-145.05
-114d6a41-5b3d-34db-b92c-a7c0da0c7a55,French Southern Territories (the),,Country,TF,-49.06,68.99
-32d7508f-e692-30cb-80af-28441ef746d9,Gabon,,Country,GA,-0.59,11.78
-92073d2f-e26e-343c-a222-cc0fb0b7d7a0,Gambia (the),,Country,GM,13.44,-15.39
-0ba64a0d-ea00-3479-96df-b6a66866e1ca,Georgia,,Country,GE,42.16,43.5
-5f02f088-9301-3d7b-a1ac-972c11bf3e7d,Germany,,Country,DE,51.1,10.38
-19b19ffc-30ca-3f1c-9376-cd2982992a59,Ghana,,Country,GH,7.95,-1.21
-28dd376c-5a44-3cc9-ae45-0ee338260c56,Gibraltar,,Country,GI,36.12,-5.34
-56bca136-90bb-3a77-9abb-7ce558af711e,Global,,Unlocated,GLO,0.0,0.0
-d692bc40-d834-33d2-8d3a-37582f58468c,Greece,,Country,GR,39.05,22.97
-ce1d5a24-80e0-34a2-91c1-c7968cc66c13,Greenland,,Country,GL,74.73,-41.34
-a6be8a33-b7c9-37f4-bfb7-6d9c9805c7eb,Grenada,,Country,GD,12.15,-61.65
-5343b21a-d303-3f17-9962-9894deca13db,Guadeloupe,,Country,GP,16.2,-61.52
-d2a460df-08a4-3b7a-958f-635b540d90cb,Guam,,Country,GU,13.44,144.77
-1bfad22f-0925-378f-b10a-37440bfdff43,Guatemala,,Country,GT,15.69,-90.36
-73c18c59-a39b-3838-a081-ec00bb456d43,Guernsey,,Country,GG,49.48,-2.53
-5123dd8b-087b-344f-9b8f-8603acd1bad4,Guinea,,Country,GN,10.43,-10.94
-3f071f4f-163d-3855-9f4f-c1544c7f69a6,Guinea-Bissau,,Country,GW,12.02,-14.97
-5e08be98-8691-354c-937b-997b4cb6ad97,Guyana,,Country,GY,4.79,-58.98
-eb5e48e7-4123-3acc-9276-1302ea4a7d22,Haiti,,Country,HT,18.93,-72.69
-2ab5564b-805d-3065-b4bc-f81060472746,Heard Island and McDonald Islands,,Country,HM,-53.08,73.5
-43b1cc1d-b7be-33d8-99dd-4280f578691a,Holy See (the),,Country,VA,41.9,12.45
-59ca4f8b-bb97-33c2-ab59-db115fcdb664,Honduras,,Country,HN,14.82,-86.62
-ae417185-6a75-37b6-bd51-fc0e1f95902e,Hong Kong,,Country,HK,22.38,114.13
-18bd9197-cb1d-333b-8352-f47535c00320,Hungary,,Country,HU,47.16,19.39
-31c68c64-6657-3dcc-bc06-2d977c76315b,"IAI Area, Africa",,Aluminium,"IAI Area, Africa",-2.34,22.31
-60a4d810-df1e-3895-95b4-025bbedca798,"IAI Area, Asia, without China and GCC",,Aluminium,"IAI Area, Asia, without China and GCC",30.78,76.41
-a2788633-a453-37e8-ac1d-c6c5b63300b2,"IAI Area, EU27 & EFTA",,Aluminium,"IAI Area, EU27 & EFTA",52.47,8.4
-a335f1f7-79cd-311f-b82e-33648aa17cd3,"IAI Area, Gulf Cooperation Council",,Aluminium,"IAI Area, Gulf Cooperation Council",21.35,55.61
-cf7ec575-43e5-3274-8c54-1e9ec72461bd,"IAI Area, North America",,Aluminium,"IAI Area, North America",55.13,-103.93
-af92823f-638d-36d7-8406-451a58f61543,"IAI Area, North America, without Quebec",,Aluminium,"IAI Area, North America, without Quebec",55.27,-106.45
-15b95f69-f97e-36b9-a54e-905eff9c2bdb,"IAI Area, Russia & Europe outside EU27 & EFTA",,Aluminium,"IAI Area, Russia & Europe outside EU27 & EFTA",61.93,96.49
-8364be66-e49f-36e8-8ea4-a8795d469fe3,"IAI Area, South America",,Aluminium,"IAI Area, South America",-15.97,-57.18
-a2a551a6-458a-3de2-a446-cc76d639a9e9,Iceland,,Country,IS,64.99,-18.59
-13b5bfe9-6f3e-3fe4-91c9-f66f4a582adf,India,,Country,IN,22.88,79.6
-7661383e-998b-4738-b8dc-9e1e60070c8a,"India, Andaman and Nicobar Islands",,Subdivisions,IN-AN,11.13,92.97
-888f6bc1-22f6-486b-b2f3-814672df6930,"India, Andhra Pradesh",,Subdivisions,IN-AP,15.72,79.92
-28388907-7605-469a-b28d-cdc8f963b28b,"India, Arunachal Pradesh",,Subdivisions,IN-AR,28.03,94.66
-d0145549-5ad2-4cc6-8e5b-c6ed6223d2db,"India, Assam",,Subdivisions,IN-AS,26.35,92.83
-5ba6d534-2083-4167-975d-84579c9e5202,"India, Bihar",,Subdivisions,IN-BR,25.66,85.6
-1b5afe13-e071-4c8a-81b5-68eb8982053f,"India, Chandigarh",,Subdivisions,IN-CH,30.74,76.76
-89f88c37-befd-49fa-92ad-35875a6709eb,"India, Chhattisgarh",,Subdivisions,IN-CG,21.25,82.03
-d766dc54-3e8f-4ac4-8a0f-69707a338b33,"India, Dadra and Nagar Haveli",,Subdivisions,IN-DN,20.16,73.03
-653869da-6e3f-476e-9380-19d23040f2b9,"India, Daman and Diu",,Subdivisions,IN-DD,20.46,72.59
-de26c625-ae68-4c9e-8fde-a6c33b3dfe14,"India, Delhi",,Subdivisions,IN-DL,28.66,77.1
-1eb1f8b3-8c35-425e-94ca-cf502eb004c3,"India, Eastern grid",,Electricity,IN-Eastern grid,23.07,85.69
-567cc8ea-05d0-4d27-a509-89f10e1a280e,"India, Goa",,Subdivisions,IN-GA,15.35,74.04
-0d325613-94aa-4a65-8014-d3f6ead19eb3,"India, Gujarat",,Subdivisions,IN-GJ,22.71,71.55
-3f1442fa-0808-438c-a355-2a1e96f9adeb,"India, Haryana",,Subdivisions,IN-HR,29.2,76.33
-763ca99d-f561-45ef-8d36-84cb877f9c08,"India, Himachal Pradesh",,Subdivisions,IN-HP,31.93,77.22
-4a07e727-a1e5-4079-8433-b1d2b5ed544c,"India, Islands",,Electricity,IN-Islands,11.12,92.87
-d8cc1385-8b61-4509-8db0-d9cb5fa95725,"India, Jammu and Kashmir",,Subdivisions,IN-JK,33.55,75.07
-2221b78c-5a1c-454c-a637-744d54a0bbe9,"India, Jharkhand",,Subdivisions,IN-JH,23.64,85.53
-c23d9dc6-d794-4775-8e92-ee830a084a7f,"India, Karnataka",,Subdivisions,IN-KA,14.71,76.15
-518f1827-fe70-400e-b521-48f2f72fd777,"India, Kerala",,Subdivisions,IN-KL,10.42,76.42
-dee052a0-3714-41b6-86c0-79d062704c25,"India, Lakshadweep",,Subdivisions,IN-LD,10.12,72.82
-b3d19998-fe81-4783-a19e-408d7424d876,"India, Madhya Pradesh",,Subdivisions,IN-MP,23.53,78.29
-14bfff77-d5a0-4ad5-9936-58636c295e99,"India, Maharashtra",,Subdivisions,IN-MH,19.46,76.11
-d6bf166c-b5aa-45a6-b0e9-7c169d2c7cbc,"India, Manipur",,Subdivisions,IN-MN,24.73,93.86
-10988ebe-8be4-43c6-8451-3273ca12cd47,"India, Meghalaya",,Subdivisions,IN-ML,25.53,91.28
-cab4fbd7-e8ae-4ea6-9e74-0e41df667c61,"India, Mizoram",,Subdivisions,IN-MZ,23.29,92.81
-df16b2b2-c49e-4560-9b74-cbcbe0a8d281,"India, Nagaland",,Subdivisions,IN-NL,26.05,94.44
-26e353a9-dac6-4123-833d-75cd720d9e19,"India, North-eastern grid",,Electricity,IN-North-eastern grid,26.3,93.42
-59003ab7-b40a-43ac-b7c9-3e3e8907803e,"India, Northern grid",,Electricity,IN-Northern grid,28.51,76.71
-bf61f94b-cbd6-4a41-9c8b-0ef2b4e06c3c,"India, Odisha",,Subdivisions,IN-OD,20.51,84.41
-f7228566-0785-45da-b946-01f82d277dda,"India, Puducherry",,Subdivisions,IN-PY,11.96,78.88
-83cdc953-e485-453b-a8f9-749f92aca417,"India, Punjab",,Subdivisions,IN-PB,30.84,75.4
-4024933b-d7a2-4ebb-87dc-80460ff13c50,"India, Rajasthan",,Subdivisions,IN-RJ,26.59,73.83
-01c44dfa-113d-427b-81b9-1d4fde230f93,"India, Sikkim",,Subdivisions,IN-SK,27.57,88.44
-8a80d1d2-de76-44e0-a3d3-46b98c053ca1,"India, Southern grid",,Electricity,IN-Southern grid,14.53,78.11
-eb2442cf-93eb-4784-99f9-7a0c97c3576f,"India, Tamil Nadu",,Subdivisions,IN-TN,11.01,78.4
-001c936c-cf14-46dd-a99e-b1ef30f51c96,"India, Tripura",,Subdivisions,IN-TR,23.75,91.72
-ae2be714-8cbe-4abd-afac-a5e7ca2b0d55,"India, Uttar Pradesh",,Subdivisions,IN-UP,26.93,80.54
-6859dfd7-168b-4a36-9429-e0e884bff83a,"India, Uttarakhand",,Subdivisions,IN-UK,30.16,79.19
-77849b53-31ea-4b25-93e5-451909753ad3,"India, West Bengal",,Subdivisions,IN-WB,23.8,87.97
-25457a88-a525-4fd8-b73d-72fd3f37fc74,"India, Western grid",,Electricity,IN-Western grid,21.7,76.77
-14b3773a-9228-3ca1-98e3-3d0017100d23,Indian Ocean Territories,,Miscellaneous,AU-IOT,-10.69,104.61
-b80bb774-0288-3da1-b201-890375a60c8f,Indonesia,,Country,ID,-2.22,117.27
-d74eea48-99a6-3f9f-8bc5-27ef988ea0ff,Iran (Islamic Republic of),,Country,IR,32.57,54.27
-795237fd-9d10-3e63-8d19-b0db0f2fba2f,Iraq,,Country,IQ,33.03,43.74
-25400724-d737-3b0b-a9c9-369d9af3dd21,Ireland,,Country,IE,53.17,-8.14
-73bebce3-95b6-31ef-adcf-6842fbdb4d76,Isle of Man,,Country,IM,54.22,-4.53
-4605f628-f91d-321e-8b5f-9433f46e29eb,Israel,,Country,IL,31.44,34.99
-0d149b90-e739-3297-b01c-90191ae775f0,Italy,,Country,IT,42.78,12.07
-3da770cc-56ed-3407-b6aa-f10ad4e72b4d,Jamaica,,Country,JM,18.15,-77.31
-55add3d8-45bf-3d87-a9b0-949b0da49c0a,Japan,,Country,JP,37.55,137.97
-79563e90-630a-3352-9dff-01b6638b0886,Jersey,,Country,JE,49.22,-2.12
-1799e32a-b029-4981-ab1b-1cd932c1e64b,Jervis Bay Territory,,Miscellaneous,AU-JB,-35.15,150.7
-674f3384-1e23-39ff-9d24-c85dc3b999de,Jordan,,Country,JO,31.24,36.77
-9008f9e2-758f-38fe-920b-1765e72734d5,Kazakhstan,,Country,KZ,48.15,67.28
-25bc6654-798e-3508-ba0b-6343212a74fe,Kenya,,Country,KE,0.55,37.82
-988287f7-a1eb-366f-bc4e-19bdbdeec7c3,Kiribati,,Country,KI,0.8,-47.73
-26b568e4-192a-364d-9b3e-acdbd632bc2e,Korea (the Democratic People's Republic of),,Country,KP,40.15,127.18
-dcf0d7d2-cd12-3bf4-a580-d43f29785dd3,Korea (the Republic of),,Country,KR,36.37,127.81
-a2d8fced-03cb-3e20-af8e-1226935c9c92,Kosovo,,Miscellaneous,XK,42.57,20.87
-048685d9-6262-3854-82a1-d5bb4a14bc3b,Kuwait,,Country,KW,29.34,47.59
-ebe86682-666f-3ab3-9a08-43ed3097e4b3,Kyrgyzstan,,Country,KG,41.46,74.54
-c9089f3c-9ada-3018-af6f-fb1ee8d6501c,Lao People's Democratic Republic (the),,Country,LA,18.5,103.73
-84502834-6281-3742-9577-a349ea768503,Latin America and the Caribbean,,Global,RLA,-10.23,-65.65
-85d1a9c4-88d7-317e-a862-91a755e5d43c,Latvia,,Country,LV,56.85,24.9
-26403ec6-d537-3a31-b63e-294b44831734,Lebanon,,Country,LB,33.92,35.87
-44ba5ca6-5651-34f3-af19-27576dd35436,Lesotho,,Country,LS,-29.57,28.22
-58791f32-2c1b-3c3d-a614-1788d3b8666f,Liberia,,Country,LR,6.45,-9.31
-e728b477-51c6-3559-82cb-60f97d1e4553,Libya,,Country,LY,27.03,18.0
-d70c1e5d-44de-3a91-90eb-91ecff563578,Liechtenstein,,Country,LI,47.13,9.54
-d91af695-8918-3f87-96a0-57c1cdf5b225,Lithuania,,Country,LT,55.32,23.88
-3e7e122b-f08f-3843-ac96-1ba491089dc9,Luxembourg,,Country,LU,49.76,6.07
-27c9d518-7cd2-33f8-9160-ec1ed2b5ac89,Macao,,Country,MO,22.15,113.55
-b351bb9b-0af6-34fc-a787-49675c53ad67,Madagascar,,Country,MG,-19.37,46.7
-38fed710-7cee-3580-98ca-06304c1beb90,Malawi,,Country,MW,-13.21,34.28
-6864f389-d987-3436-bc87-78ff071d1b6c,Malaysia,,Country,MY,3.79,109.69
-94d03594-5b3d-3218-a669-c4d3f6daa104,Maldives,,Country,MV,3.82,73.3
-9830e1f8-1f62-3b33-906a-cc186b93374e,Mali,,Country,ML,17.34,-3.53
-710998fd-1b7c-3235-9702-65650770a4b1,Malta,,Country,MT,35.92,14.4
-ed8f5b7e-7439-3143-b43a-93dc753618ae,Marshall Islands (the),,Country,MH,7.11,170.09
-1d8a4975-693e-31eb-9ca5-4878098d608f,Martinique,,Country,MQ,14.65,-61.01
-d9394066-970e-34ae-a52f-d0347e58c03e,Mauritania,,Country,MR,20.25,-10.34
-89aa4b19-6b48-38a1-ba65-49bb1eaebd80,Mauritius,,Country,MU,-20.18,57.84
-fa0ed5b5-c600-345b-9d9a-299952b99651,Mayotte,,Country,YT,-12.81,45.14
-9c7e385f-c425-3258-a571-a94454d24b2b,Melanesia,,Global,UN-MELANESIA,-7.76,147.88
-3d26b0b1-7065-32cf-a9c0-6c010184c684,Mexico,,Country,MX,23.94,-102.53
-11a4769f-1f94-3ef6-9be6-a120cd4e3e67,Micronesia,,Global,UN-MICRONESIA,8.01,95.93
-0ab34ca9-7d99-3659-9bf8-9817789cb5de,Micronesia (Federated States of),,Country,FM,7.04,155.19
-e71864bf-656a-3133-8489-a428120c0ada,Middle Africa,,Global,UN-MAFRICA,0.61,19.46
-4b24ca1d-6a54-335b-811e-38a32aaa0967,Middle East,,Global,RME,28.63,48.65
-483bbc62-bf06-31a1-9aca-efa0a24e2f1e,Middle East and North Africa,,Global,MEA,28.63,34.24
-793914c9-c583-39d8-ad0f-4ed8c521b0c1,Moldova (the Republic of),,Country,MD,47.19,28.46
-d6fd0924-e324-3506-a9ae-0295adf59567,Monaco,,Country,MC,43.73,7.39
-41256636-7c67-348b-999d-1b7666f8ccfc,Mongolia,,Country,MN,46.82,103.05
-ab86a1e1-ef70-3ff9-b959-067b723c5c24,Montenegro,,Country,ME,42.78,19.23
-ee33e909-372d-335d-990f-4fcb2a92d542,Montserrat,,Country,MS,16.73,-62.18
-b74df323-e393-3b56-b635-a2cba7a7afba,Morocco,,Country,MA,29.84,-8.39
-4f3dd0ff-b3e4-3c5f-b4b5-b0d8c1f10bb5,Mozambique,,Country,MZ,-17.27,35.53
-b3cd915d-7580-38bd-99d0-f2428fbb354a,Myanmar,,Country,MM,21.16,96.48
-6ec66e12-4fb9-3c19-8e92-07b0b82f542a,Namibia,,Country,NA,-22.12,17.21
-0ab3e5d0-801a-3a3f-b758-bcbd812e8f10,Nauru,,Country,NR,-0.52,166.93
-40590d3d-1a34-3650-81f5-e48b08ef2096,Near East,,Global,RNE,33.72,39.81
-cf3fc916-339b-32ad-9c14-aca2425ccf53,Nepal,,Country,NP,28.24,83.91
-1a13105b-7e4e-35fb-ae7c-9515ac06aa48,Netherlands (Kingdom of the),,Country,NL,52.26,5.58
-18b049cc-8d85-3578-b929-df716f9f4e68,Netherlands Antilles,,Miscellaneous,AN,12.66,-67.81
-1e734284-5e24-3b3b-9b35-54490da1c128,New Caledonia,,Country,NC,-21.3,165.7
-c97b334f-fd41-3a49-9708-3f1949632bc1,New Zealand,,Country,NZ,-41.82,171.47
-e6c151d4-49e1-3b05-b1ff-b5ad5ec656cf,Nicaragua,,Country,NI,12.84,-85.03
-d4f91763-3649-33c4-bc7a-b917fa990146,Niger (the),,Country,NE,17.41,9.38
-66e10e9f-f65e-3479-a54d-de3968d3440d,Nigeria,,Country,NG,9.59,8.09
-0288bde0-c2d5-33f2-b576-6f61b826a650,Niue,,Country,NU,-19.04,-169.86
-78d9238c-1a21-3c8b-be8f-6c26172fb12d,Norfolk Island,,Country,NF,-29.03,167.95
-aab06382-a476-4bec-a78b-d2fc0b849980,North America without Quebec,,Cutout,North America without Quebec,55.27,-106.45
-d9a20693-e28e-33ac-aa03-8df3b3bfa273,"North America, Alaska Systems Coordinating Council",,Electricity,US-ASCC,64.26,-152.27
-679f547e-8973-3198-9562-f49522f5f5ac,"North America, Electric Reliability Council of Texas",,Electricity,US-ERCOT,31.1,-97.64
-d1e780c1-ae55-3086-82ed-b9f568342c46,"North America, Florida Reliability Coordinating Council",,Electricity,US-FRCC,28.34,-81.9
-add33b5c-114e-39e1-8996-ebe46366c661,"North America, Hawaii Power Grid",,Electricity,US-HICC,20.25,-156.35
-cda0fd29-18d1-3e20-ac87-1ed79a8d2bb0,"North America, Midwest Reliability Organization",,Electricity,MRO,48.38,-99.5
-8ce8d793-183f-312a-a33c-5c61ec31edb6,"North America, Midwest Reliability Organization, US part only",,Electricity,US-MRO,42.2,-97.41
-588c9ca2-d66d-3e43-b7b3-65bfd7e971cf,"North America, Northeast Power Coordinating Council",,Electricity,NPCC,51.08,-76.5
-50f826e7-ab13-444e-987b-180701b691c9,"North America, Northeast Power Coordinating Council, US part only",,Electricity,US-NPCC,43.69,-72.87
-6c68ef81-a341-3ab2-bc21-e280c511bd86,"North America, Quebec, Hydro-Quebec distribution network",,Electricity,"Québec, HQ distribution network",53.38,-71.78
-1560a2df-f599-3750-9974-8cbda44b4c51,"North America, ReliabilityFirst Corporation",,Electricity,US-RFC,41.82,-83.2
-44193271-0d3b-309d-b869-820f52c4c6db,"North America, SERC Reliability Corporation",,Electricity,US-SERC,34.46,-86.47
-5566919c-eb38-3560-957c-4fddbf8314c7,"North America, Southwest Power Pool",,Electricity,US-SPP,36.18,-97.9
-7e764aa6-b752-3530-855f-0373606d1886,"North America, Texas Regional Entity",,Electricity,US-TRE,31.23,-99.21
-f62a6cfc-7bf3-3556-a8b3-a168accf9875,"North America, Western Electricity Coordinating Council",,Electricity,WECC,46.56,-116.16
-f37ced82-5df8-48c2-a207-1e36dd11a112,"North America, Western Electricity Coordinating Council, US part only",,Electricity,US-WECC,40.71,-113.13
-16096b94-483a-3671-b7a2-16db4118f8df,North American Free Trade Agreement,,Miscellaneous,NAFTA,53.3,-103.84
-07d93568-0b65-31b2-a42f-e4baea021389,North Macedonia,,Country,MK,41.59,21.68
-f9d758b6-d15e-3238-aa0e-e0a3b949fc32,Northern Africa,,Global,UN-NAFRICA,25.13,14.87
-b320e7db-c758-3ba6-8839-81eb83c9d7d7,Northern America,,Global,RNA,58.86,-92.02
-bd6ef2ee-f612-38be-bce0-90c8e64ebaa9,Northern Cyprus,,Miscellaneous,Northern Cyprus,35.27,33.59
-da657f65-6f70-3a48-893f-64cf7be37d09,Northern Europe,,Global,UN-NEUROPE,63.05,13.82
-1f2dfa56-7dcf-3583-bedd-f7aec167fec7,Northern Mariana Islands (the),,Country,MP,16.25,145.59
-7fa3b767-c460-354a-abe4-d49030b349c7,Norway,,Country,NO,64.46,14.08
-61c8d2f5-500d-37c3-a13e-4ed176dcf6d2,Oceania,,Global,UN-OCEANIA,-25.28,136.41
-6aa2b79b-1fc3-384c-b1af-565b51d5e4ad,Oceanic,,Global,OCE,-25.28,136.41
-d58da822-8993-3d8c-8ec4-f40689c2847e,Oman,,Country,OM,20.6,56.09
-cd0acfe0-85ee-30f8-b439-1fb9b8009bed,Pacific Asia,,Global,PAS,12.39,123.83
-655ae040-aec1-37f7-8d79-0580c5ac37ab,Pacific OECD,,Global,PAO,-9.99,148.97
-1cd3c693-132f-3c31-b5b5-e5f4c5eed6bd,Pakistan,,Country,PK,29.94,69.34
-8fe4c114-5128-3c09-8a65-78e6ddbf5eed,Palau,,Country,PW,7.19,134.34
-8812c36a-a5ae-336c-aa77-bf63211d899a,"Palestine, State of",,Country,PS,31.91,35.2
-e529a9ce-a4a7-38eb-9c58-28b13b22844c,Panama,,Country,PA,8.51,-80.12
-235ec523-92b7-3977-939c-f78b62e708d3,Papua New Guinea,,Country,PG,-6.47,145.23
-dfed5bc1-77b8-3ab3-97c5-84e06566adc6,Paraguay,,Country,PY,-23.22,-58.39
-dd07de85-6139-3a7c-b7f8-fcc1752d45e1,Peru,,Country,PE,-9.15,-74.37
-da984e42-a589-3bbd-ac49-6ef0cbadcee2,Philippines (the),,Country,PH,11.76,122.87
-ded0804c-f804-36d2-ae37-953dc2dbc505,Pitcairn,,Country,PN,-24.41,-128.47
-28840420-4e3d-3522-a930-8317344a285d,Poland,,Country,PL,52.12,19.39
-b9b1f592-541c-3b02-bd41-1f6ea05a6ea5,Polynesia,,Global,UN-POLYNESIA,-15.31,-158.36
-fc9fdf08-4e29-3f26-a270-390dc49061a2,Portugal,,Country,PT,39.58,-8.59
-561193d1-987d-3e23-8831-37583bb484ef,"Portugal, Madeira",,Miscellaneous,PT-30,32.74,-16.97
-64e1e1cb-e1ca-3e88-af3a-838a3e7b57d6,Puerto Rico,,Country,PR,18.22,-66.46
-8264ee52-f589-34c0-991a-a94f87aa1aeb,Qatar,,Country,QA,25.31,51.18
-81e54bf8-5993-5b5b-bc50-6978cab0c51f,Rest of Europe,,Unlocated,RoE,0.0,0.0
-f1965a85-7bc2-35d2-afe2-2023aa5ab50d,Rest of World,,Unlocated,RoW,0.0,0.0
-3605c251-087b-3821-ac9b-ca890e07ad9c,Romania,,Country,RO,45.85,24.97
-84c26536-0d12-33e3-8ed0-e7fa435f9a45,Russia (Asia),,Miscellaneous,Russia (Asia),62.73,110.63
-7d199e42-c733-3c12-87e1-ce5672f33ae6,Russia (Europe),,Miscellaneous,Russia (Europe),59.24,45.62
-89484b14-b36a-3d53-a942-6a3d944d2983,Russian Federation (the),,Country,RU,61.98,96.69
-038c0dc8-a958-3fea-97af-047244fb6960,Rwanda,,Country,RW,-1.99,29.91
-12eccbdd-9b32-3181-b134-1f38907cbbb5,Réunion,,Country,RE,-21.11,55.54
-fd18772c-bac1-3277-b20d-cccc1b90efb9,Saint Barthélemy,,Country,BL,17.9,-62.83
-77cbc257-e663-3286-acf6-191754c0c8e3,"Saint Helena, Ascension and Tristan da Cunha",,Country,SH,-24.91,-10.13
-8c7e6965-b416-3689-a88b-313bbe7450f9,Saint Kitts and Nevis,,Country,KN,17.27,-62.69
-196accbc-f32b-3a8e-abef-92e1a37d0fc0,Saint Lucia,,Country,LC,13.9,-60.97
-ea81aa7d-f47d-34c6-b37b-f98fabf3ff82,Saint Martin (French part),,Country,MF,18.07,-63.05
-5109d85d-95fe-3e78-96d9-704e6e5b1279,Saint Pierre and Miquelon,,Country,PM,46.93,-56.3
-c56e5259-4d4e-3e7f-acb2-b96c4637b486,Saint Vincent and the Grenadines,,Country,VC,13.21,-61.2
-742523da-ef59-3b4b-b184-09f46de05d0c,Samoa,,Country,WS,-13.75,-172.16
-ed79acb0-cd3d-3f83-a0c5-3c7798335ef0,San Marino,,Country,SM,43.93,12.44
-627fcdb6-cc9a-3e16-9657-ca6cdef0a6bb,Sao Tome and Principe,,Country,ST,0.44,6.72
-c12e01f2-a13f-3558-be1e-9e4aedb8242d,Saudi Arabia,,Country,SA,24.12,44.53
-d0ea3a63-8908-3b86-a4f9-10b6170de942,Scarborough Reef,,Miscellaneous,Scarborough Reef,15.15,117.75
-afbe94cd-be69-393e-babc-9f1325fc7dff,Senegal,,Country,SN,14.36,-14.47
-3a2d7564-baee-3918-aebc-7b65084aabd1,Serbia,,Country,RS,44.22,20.78
-95cc64dd-2825-39df-93ec-4ad683ecf339,Serbia and Montenegro,,Miscellaneous,CS,44.01,20.56
-cc9dabdf-852c-3698-ae98-b3d1d8b1c324,Serranilla Bank,,Miscellaneous,Serranilla Bank,15.86,-78.63
-d54185b7-1f61-3c30-a396-ac4bc44d3269,Seychelles,,Country,SC,-6.48,52.06
-5f507fb0-b905-3a32-bb57-967d0a3b3b43,Siachen Glacier,,Miscellaneous,Siachen Glacier,35.39,77.17
-54a2bf8c-09ac-367d-b513-aaa1aa7aa0f3,Sierra Leone,,Country,SL,8.56,-11.79
-5dae4296-88af-3c52-9ad8-7ac394192c6d,Singapore,,Country,SG,1.35,103.81
-2c38b9e4-5cec-3b32-8dde-4e3d5b22c648,Sint Maarten (Dutch part),,Country,SX,18.04,-63.07
-41d6ad07-61a5-327a-9e1b-d567041ce9e9,Slovakia,,Country,SK,48.7,19.48
-ac5585d9-8646-3255-a99c-359140537783,Slovenia,,Country,SI,46.11,14.8
-26148d62-1ef7-3844-918a-f182d63976b6,Solomon Islands,,Country,SB,-8.9,159.63
-b807023f-87e6-3b8a-9a92-f79f546ff9cc,Somalia,,Country,SO,4.74,45.7
-4f146d3d-de5e-3896-8bac-17f57c9eaa05,Somaliland,,Miscellaneous,Somaliland,9.73,46.25
-959848ca-10cc-3a60-9a81-8ac11523dc63,South Africa,,Country,ZA,-29.0,25.08
-d34c6aba-144a-3e2d-acb4-0dd5f93ae50e,South America,,Global,UN-SAMERICA,-15.15,-60.78
-1d8d5e91-2302-308b-9e88-c3e77fcad378,South Georgia and the South Sandwich Islands,,Country,GS,-54.67,-35.89
-3691308f-2a4c-3f69-83f2-880d32e29c84,South Sudan,,Country,SS,7.28,30.3
-e832ff92-78c2-3ab2-8f7d-d0ca126994bf,South-Eastern Asia,,Global,UN-SEASIA,7.94,109.91
-326dde39-0b64-3523-b09f-aa0f427066d8,Southern Africa,,Global,UN-SASIA,-25.49,22.52
-a8a64cef-262a-34de-8872-b68b63ab7cd8,Southern Asia,,Global,SAS,27.43,70.79
-fe8f0f22-0c96-348b-86c2-b27e42d27f04,Southern Europe,,Global,UN-SEUROPE,41.48,7.29
-12470fe4-06d4-3017-996e-ab37dd65fc14,Spain,,Country,ES,40.22,-3.65
-e914aa2b-6272-3660-9305-a03124b4d9a8,Spratly Islands,,Miscellaneous,Spratly Islands,10.54,114.92
-d0fa06cd-9333-3c8c-ae35-7ffe5cd1c4e9,Sri Lanka,,Country,LK,7.61,80.7
-748ced3d-d3ad-3822-bb8f-2e73f28ef722,Sub-Sahara Africa,,Global,AFR,-1.23,18.32
-6226f7cb-e59e-39a9-8b5c-ef6f94f966fd,Sudan (the),,Country,SD,15.98,29.93
-e22428cc-f96c-3a96-b4a9-39c209ad1000,Suriname,,Country,SR,4.13,-55.91
-b5bf27b2-555d-344e-bdf2-230080db5a1d,Svalbard and Jan Mayen,,Country,SJ,78.86,18.47
-efad7abb-323e-3d40-9628-4c8a6da076a1,Sweden,,Country,SE,62.77,16.75
-d88fc6ed-f21e-3464-935f-f76288b84103,Switzerland,,Country,CH,46.79,8.21
-1548af1c-94ad-3558-8324-df8f08baf227,Syrian Arab Republic (the),,Country,SY,35.02,38.5
-255a5cac-7685-3722-b4d0-2f04c37be771,Taiwan (Province of China),,Country,TW,23.75,120.94
-456c2e75-fe0f-3a57-bd1c-fd87117e0963,Tajikistan,,Country,TJ,38.52,71.01
-73bb4387-b307-3739-aacb-9cd62ac4049c,"Tanzania, the United Republic of",,Country,TZ,-6.27,34.81
-1fdc0f89-3412-3e55-b0d2-811821b84d3b,Thailand,,Country,TH,15.11,101.0
-313a21d5-badc-3f56-b223-8ebf8c7690f6,Timor-Leste,,Country,TL,-8.82,125.85
-1f0eb098-5870-335e-a2fa-2f68a223b173,Togo,,Country,TG,8.52,0.96
-b6717b91-c759-3cc0-bf30-aa9a784e6390,Tokelau,,Country,TK,-8.96,-171.81
-01b6e203-44b6-3835-85ed-1ddedf20d531,Tonga,,Country,TO,-19.96,-174.84
-accc9105-df53-3311-9407-fd5b41255e23,Trinidad and Tobago,,Country,TT,10.46,-61.25
-aafb96b2-fa88-36be-b07c-4496867bad56,Tunisia,,Country,TN,34.11,9.55
-6a962563-e235-3178-9e66-3e356ac8d9e4,Turkmenistan,,Country,TM,39.11,59.37
-5c4fefda-27cf-384c-b999-be13e6b8608a,Turks and Caicos Islands (the),,Country,TC,21.78,-71.87
-c9a1fdac-6e08-3dd8-9e71-73244f34d7b3,Tuvalu,,Country,TV,-7.75,178.52
-e7d707a2-6e7f-3b6f-b52c-489c60e429b1,Türkiye,,Country,TR,39.06,35.16
-2a0617ac-cf8b-3862-9c43-e2ffeb5b8d5b,Uganda,,Country,UG,1.27,32.36
-5269f4d7-5f5b-375f-8f94-bab2100a5531,Ukraine,,Country,UA,49.16,31.25
-b6bb43df-4525-3928-a105-fb5741bddbea,United Arab Emirates (the),,Country,AE,23.9,54.3
-7885444a-f42e-3b30-8518-c5be17c8850b,United Kingdom of Great Britain and Northern Ireland (the),,Country,GB,54.14,-2.88
-0dd00e33-b6fc-37b8-91eb-e3177217d6c0,United States Minor Outlying Islands (the),,Country,UM,14.01,-97.16
-0b3b97fa-6688-3c56-88ee-4ae80ec0c3c2,United States of America (the),,Country,US,45.68,-112.49
-c385c23d-66c3-3558-989c-db5586384532,"United States of America, Alabama",,Subdivisions,US-AL,32.78,-86.82
-b423ff37-b678-3ea4-9366-ede7b1a7c0c0,"United States of America, Alaska",,Subdivisions,US-AK,64.26,-152.27
-b7745632-fc6d-37f8-85f0-f53c48027b96,"United States of America, Arizona",,Subdivisions,US-AZ,34.29,-111.66
-b54bf461-c111-318c-9f92-a499f34dc05d,"United States of America, Arkansas",,Subdivisions,US-AR,34.9,-92.44
-b775ab58-2693-342d-b496-3265a17b5b32,"United States of America, California",,Subdivisions,US-CA,37.24,-119.6
-12fe7ead-4836-3c05-bbd9-768e2f0fdb66,"United States of America, Colorado",,Subdivisions,US-CO,38.99,-105.54
-e86115dd-61e0-3652-8b8f-79fc693dcf01,"United States of America, Connecticut",,Subdivisions,US-CT,41.62,-72.72
-1ae4da05-1c10-36a3-aadc-da3431d1b677,"United States of America, Delaware",,Subdivisions,US-DE,38.99,-75.5
-efe104ea-d72b-3371-940f-1bb877257ab3,"United States of America, District of Columbia",,Subdivisions,US-DC,38.9,-77.01
-445fe89e-beea-3ff9-8975-167f35b53373,"United States of America, Florida",,Subdivisions,US-FL,28.64,-82.48
-2b701fc6-ef0e-3b9a-9f4d-631863e904f6,"United States of America, Georgia",,Subdivisions,US-GA,32.65,-83.45
-fe2bd352-e70f-3e48-a023-02843b5ac978,"United States of America, Hawaii",,Subdivisions,US-HI,20.25,-156.35
-1f80437b-a9fb-34e0-a052-26a2a7fd5520,"United States of America, Idaho",,Subdivisions,US-ID,44.39,-114.65
-c2521c9e-e466-3960-b789-4046cadadf24,"United States of America, Illinois",,Subdivisions,US-IL,40.12,-89.15
-70f8ca91-42c2-3bae-a4e2-dcc1b8033abe,"United States of America, Indiana",,Subdivisions,US-IN,39.91,-86.28
-fa384517-d567-36e2-9a5a-dd52df663dcf,"United States of America, Iowa",,Subdivisions,US-IA,42.07,-93.49
-d9c55cbc-3e12-3ff1-9370-bdfebddccd5f,"United States of America, Kansas",,Subdivisions,US-KS,38.48,-98.38
-e132e45b-712d-3e2c-af19-c1f1b99c3c91,"United States of America, Kentucky",,Subdivisions,US-KY,37.52,-85.29
-c384a41a-bbea-3bc9-b333-75287ddb64bb,"United States of America, Louisiana",,Subdivisions,US-LA,31.07,-92.01
-4d844119-4127-3a4d-b856-663e8039d21c,"United States of America, Maine",,Subdivisions,US-ME,45.38,-69.23
-86596f8c-55cb-3a71-976f-6a56e871f29b,"United States of America, Maryland",,Subdivisions,US-MD,39.05,-76.79
-85a8277c-cb62-3889-ae66-71d05d9263d3,"United States of America, Massachusetts",,Subdivisions,US-MA,42.25,-71.8
-bb966cd1-e1ba-33fd-8375-56d66970d7df,"United States of America, Michigan",,Subdivisions,US-MI,44.87,-85.73
-7aa1c4da-339b-3230-8838-2de0f6a6581a,"United States of America, Minnesota",,Subdivisions,US-MN,46.34,-94.19
-0ee63262-59b9-3da8-8cf7-5f42828ffa7b,"United States of America, Mississippi",,Subdivisions,US-MS,32.76,-89.67
-cdc9423a-0890-3494-b717-51263425bcf6,"United States of America, Missouri",,Subdivisions,US-MO,38.37,-92.48
-a220b227-87c9-368d-8bfe-5ff357517419,"United States of America, Montana",,Subdivisions,US-MT,47.03,-109.63
-669eb22e-cf87-3b59-a553-06880eed6a5a,"United States of America, Nebraska",,Subdivisions,US-NE,41.52,-99.8
-f9eab7a5-2fbd-36f4-b88f-438ba1a8da94,"United States of America, Nevada",,Subdivisions,US-NV,39.35,-116.65
-ca2b1447-f5e7-3554-b244-ee56ce0e92ff,"United States of America, New Hampshire",,Subdivisions,US-NH,43.68,-71.57
-52c1fc37-d9e9-33a1-aaea-c2bc601b0364,"United States of America, New Jersey",,Subdivisions,US-NJ,40.19,-74.66
-560e664b-9150-3314-b530-1eaa6af5b067,"United States of America, New Mexico",,Subdivisions,US-NM,34.42,-106.11
-0efe3dd6-681d-3dd2-8970-52bea5982168,"United States of America, New York",,Subdivisions,US-NY,42.99,-75.68
-cf1fe73c-b3b8-3e6a-a362-a24cc00edca8,"United States of America, North Carolina",,Subdivisions,US-NC,35.54,-79.39
-7d5a6438-e66c-37d7-b069-9f6cbb9efb22,"United States of America, North Dakota",,Subdivisions,US-ND,47.44,-100.47
-8f530ffb-71ad-30e5-8e27-ea335b94166f,"United States of America, Ohio",,Subdivisions,US-OH,40.41,-82.71
-9704b0fb-3771-33d7-a07d-a7d6e1a431a2,"United States of America, Oklahoma",,Subdivisions,US-OK,35.58,-97.51
-7fb70584-7e67-3d35-9d3a-16a62784d3a3,"United States of America, Oregon",,Subdivisions,US-OR,43.94,-120.54
-22b8b398-1b5b-3955-a162-614bb67b5927,"United States of America, Pennsylvania",,Subdivisions,US-PA,40.89,-77.84
-869d2f4d-09bf-3b85-b19d-3cd046b07ac5,"United States of America, Rhode Island",,Subdivisions,US-RI,41.67,-71.55
-58a2cc24-3eaf-3596-988e-742e109b66fd,"United States of America, South Carolina",,Subdivisions,US-SC,33.91,-80.89
-112e6937-5e63-32a1-ba68-730cbd933c75,"United States of America, South Dakota",,Subdivisions,US-SD,44.43,-100.23
-1be0b149-5590-34c3-bee8-fdb3255c95f4,"United States of America, Tennessee",,Subdivisions,US-TN,35.84,-86.34
-f767f1ae-d126-3766-846d-62fa2f6f927f,"United States of America, Texas",,Subdivisions,US-TX,31.5,-99.35
-10334e82-fe92-33bf-9d45-2decb730b1c2,"United States of America, Utah",,Subdivisions,US-UT,39.32,-111.67
-3b7e10ba-fd35-381d-8ff5-8811c0f6bf32,"United States of America, Vermont",,Subdivisions,US-VT,44.07,-72.66
-4ec8c4f4-fd4d-3a38-80a5-7446f9420f11,"United States of America, Virginia",,Subdivisions,US-VA,37.51,-78.84
-9ef574c2-cd1a-3866-b782-5e74b2c6cfcb,"United States of America, Washington",,Subdivisions,US-WA,47.38,-120.43
-a8ce62fb-3610-311c-8af0-a8bf4942f5a0,"United States of America, West Virginia",,Subdivisions,US-WV,38.64,-80.61
-38af12ff-e146-3293-a429-6ddf9c28b806,"United States of America, Wisconsin",,Subdivisions,US-WI,44.64,-89.73
-373367f9-6d69-3917-ac7a-b9b523b4f30f,"United States of America, Wyoming",,Subdivisions,US-WY,42.99,-107.55
-1b23f8a4-c97c-355f-b57e-c2aae921f03d,Uruguay,,Country,UY,-32.79,-56.01
-aae773f6-9106-3fd9-95d0-c38764e6dccd,US Naval Base Guantanamo Bay,,Miscellaneous,US Naval Base Guantanamo Bay,19.92,-75.15
-8b3274b7-55aa-3339-82f5-7fb557e25923,Uzbekistan,,Country,UZ,41.75,63.13
-0730b75e-96c0-353b-9b19-6be7ff4fa194,Vanuatu,,Country,VU,-16.2,167.7
-eabb18f0-a40c-3b35-9237-0c9e1bc1d61e,Venezuela (Bolivarian Republic of),,Country,VE,7.12,-66.16
-5e9c52c6-d618-381e-bd9d-62a294c4979c,Viet Nam,,Country,VN,16.64,106.3
-1815235d-384d-3912-9466-8c73298f1e52,Virgin Islands (British),,Country,VG,18.5,-64.5
-35b36b28-916d-38b3-8abd-df832e286126,Virgin Islands (U.S.),,Country,VI,17.98,-64.79
-c1b291cb-8522-336e-8217-31b509c9fcdd,Wallis and Futuna,,Country,WF,-13.84,-177.23
-fb033b5d-d7d0-37f5-a147-c0bfed75d56c,Western Africa,,Global,UN-WAFRICA,14.74,-1.18
-02cb9a5a-488d-3ea0-84d9-3ae7b315e386,Western Asia,,Global,UN-WASIA,29.57,46.32
-27ec30d1-c271-32b7-8cdf-d39530307275,Western Europe,,Global,WEU,48.53,6.47
-28c494da-87ff-3996-9927-ac34ba30adbe,Western Sahara,,Country,EH,24.23,-12.21
-00c66f1a-036b-38f9-8b70-9cb8d925d3d9,Yemen,,Country,YE,15.9,47.59
-d9c29677-6530-3ff5-92a5-ab979ed1f7a0,Zambia,,Country,ZM,-13.46,27.77
-a1555463-c361-3703-aa27-4a8b44e29192,Zimbabwe,,Country,ZW,-19.0,29.85
-9cea1e24-73aa-3499-95fa-34faac95b3e7,Åland Islands,,Country,AX,60.11,20.15
+af92823f-638d-36d7-8406-451a58f61543,"AI producing Area 2, North America, without Quebec","reference location, sources:  ecoinvent 3",,"IAI Area 2, without Quebec",55.96,-91.69
+f0357a3f-154b-32ff-a2bf-f55055457068,Afghanistan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AF,33.67,65.21
+0d0ac1d0-76ad-307d-8b0e-05f06c746da9,Africa,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RAF,6.41,18.28
+9ebe579b-1c4d-361f-97a7-4d7f59fcb7a6,Akrotiri Sovereign Base Area,"reference location, sources:  ecoinvent 3.2",,Akrotiri,34.63,32.93
+31c68c64-6657-3dcc-bc06-2d977c76315b,"Al producing Area 1, Africa","reference location, sources:  ecoinvent 3",,IAI Area 1,-2.34,22.31
+cf7ec575-43e5-3274-8c54-1e9ec72461bd,"Al producing Area 2, North America","reference location, sources:  ecoinvent 3",,"Al producing Area 2, North America",55.13,-103.95
+8364be66-e49f-36e8-8ea4-a8795d469fe3,"Al producing Area 3, South America","reference location, sources:  ecoinvent 3",,IAI Area 3,-15.98,-57.19
+bf69fffd-74b6-38ce-8f6d-ceb50bafc212,"Al producing Area 6A, West Europe","reference location, sources:  ecoinvent 3",,IAI Area 6A,52.13,6.08
+6283d7a2-fe9b-303e-bb10-35a6cba0804d,"Al producing Area 6B, East/Central Europe","reference location, sources:  ecoinvent 3",,IAI Area 6B,61.28,92.9
+a335f1f7-79cd-311f-b82e-33648aa17cd3,"Al producing Area 8, Gulf-Aluminium Council/Gulf Region","reference location, sources:  ecoinvent 3",,IAI Area 8,21.35,55.61
+d9a20693-e28e-33ac-aa03-8df3b3bfa273,Alaska Systems Coordinating Council,"reference location, sources:  ecoinvent 3",,ASCC,60.53,-143.14
+97282b27-8e5d-3186-af8e-57204e4820e5,Albania,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AL,41.14,20.06
+0de7b6a6-1a70-388b-a6e6-eeb3113531a3,Algeria,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DZ,28.16,2.63
+a2788633-a453-37e8-ac1d-c6c5b63300b2,"Aluminium producing area, EU27 and EFTA countries","reference location, sources:  ecoinvent 3.2",,"IAI Area, EU27 & EFTA",53.93,8.96
+15b95f69-f97e-36b9-a54e-905eff9c2bdb,"Aluminium producing area, Europe outside EU27 and EFTA","reference location, sources:  ecoinvent 3.2",,"IAI Area, Europe outside EU & EFTA",61.93,96.49
+f970e276-7d0c-3e75-876e-a857f92e319b,American Samoa,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AS,-14.31,-170.73
+6b356dcf-86c7-3e74-826f-3ae5725687d3,Americas,"reference location, sources:  ecoinvent 3",,UN-AMERICAS,35.54,-83.1
+523af537-946b-39c4-b836-9ed39ba78605,Andorra,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AD,42.54,1.57
+adac5e63-f80f-3629-a957-3527b25891d3,Angola,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AO,-12.29,17.54
+4921c0e2-d1f6-305a-be1f-9ec2e2041909,Anguilla,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AI,18.23,-63.03
+b2b04af9-f8f3-3b06-a29e-03ac8d3c24ca,Antarctica,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AQ,-80.44,21.3
+4e42f7dd-43ec-3fe1-84de-58610557c5ba,Antigua and Barbuda,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AG,17.07,-61.78
+c582dec9-43ff-3b74-baa0-691df291cea6,Argentina,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AR,-35.37,-65.16
+c04cd38a-eb30-33ad-9f8a-b4e64a0ded7b,Armenia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AM,40.53,44.56
+b787d22d-9cb0-3342-a58b-f546039117bc,Aruba,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AW,12.51,-69.97
+bc388e13-830e-35bd-8be3-d90b027ac5ad,Ashmore and Cartier Islands,"reference location, sources:  ecoinvent 3.2",,AUS-AC,-12.43,123.58
+1c280670-4821-3d48-b168-efc6d6685406,Asia,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RAS,45.2,96.07
+9331c8d7-3b48-3a8f-a4a8-2ea976840ba9,Asia without China,"reference location, sources:  ecoinvent 3.2",,Asia without China,47.17,94.01
+e39deabc-78c0-37a0-a5dd-30a225aa9eec,"Asia, UN Region","reference location, sources:  ecoinvent 3",,UN-ASIA,32.22,84.57
+8bcc25c9-6aa5-371f-ba76-309077753e67,Australia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AU,-24.97,136.18
+05b093bc-7b17-3c30-a09d-1c41f13e009a,Australia and New Zealand,"reference location, sources:  ecoinvent 3",,UN-AUSTRALIANZ,-26.38,135.98
+3e91fecc-17db-3393-ad8f-0e2c0131053d,Australian Capital Territory,"reference location, sources:  ecoinvent 3.2",,AUS-ACT,-35.49,149.0
+7d0db380-a5b9-3a8b-a1da-0bca241abda1,Austria,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AT,47.68,14.91
+cc8c0a97-c2df-3d73-8aff-160b65aa39e2,Azerbaijan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AZ,40.43,47.39
+7c9df801-238a-3e28-8ae2-675fd3166a1a,Bahamas,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BS,24.62,-78.01
+c08bba7a-0c03-36f1-951e-8474d853ecbf,Bahrain,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BH,26.01,50.56
+cfd7a475-f752-3ef8-95e8-d042c4511dd3,Bajo Nuevo Bank (Petrel Is.),"reference location, sources:  ecoinvent 3.2",,Bajo Nuevo,15.81,-79.83
+b380c952-746f-3cf9-89ae-d6562c7ee132,Baltic System Operator,"reference location, sources:  ecoinvent 3",,BALTSO,56.81,24.72
+c419b06b-4c65-39b5-8ff0-5adb3b8424f1,Bangladesh,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BD,24.21,89.94
+21ad0bd8-36b9-3d08-b4cf-640b4c298e7c,Barbados,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BB,13.15,-59.55
+df3f079d-e696-3496-b046-0dcfdbf9bca3,Belarus,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BY,53.54,28.04
+910955a9-07e7-39b8-9ec8-855763108a29,Belgium,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BE,50.64,4.66
+b005ad12-9444-3268-8084-f19bf5e19729,Belize,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BZ,17.21,-88.6
+39b9df3a-0fb3-356d-91a6-3e22260e96ab,Benin,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BJ,10.54,2.46
+08424385-5820-39ca-87f4-66f645784636,Bermuda,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BM,32.33,-64.7
+69206263-69b1-3058-84f5-e3d6f93b5f6e,Bhutan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BT,27.41,90.42
+ad7532d5-b386-3a40-8fbe-01f9455dca36,"Bolivia, Plurinational State of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BO,-16.71,-64.67
+52196aa5-4f16-34f9-acbf-26439c42c763,"Bonaire, Sint Eustatius and Saba","reference location, sources: ISO 3166-1, ecoinvent 3",,BQ,12.56,-68.33
+07159c47-ee1b-39ae-8fb9-c40d480856c4,Bosnia and Herzegovina,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BA,44.16,17.78
+823355b6-3ab3-3f0a-8e4d-1367e89abd1c,Botswana,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BW,-22.18,23.81
+121aa3ee-4a7d-3b1b-bbc7-60fd0c6de79b,Bouvet Island,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BV,-54.42,3.41
+dc634e20-7282-3fe0-b5be-9a2063390544,Brazil,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BR,-10.77,-53.08
+f98ed07a-4d5f-30f7-9e14-10d905f1477f,British Indian Ocean Territory,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IO,-7.33,72.41
+4e58188f-f528-3ea1-aec7-38fffc0e118d,Brunei Darussalam,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BN,4.46,114.59
+5523c88d-d347-31b7-8c61-7f632b7efdb7,Bulgaria,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BG,42.76,25.23
+c9f9d7dd-806c-3412-a041-837a80f47c64,Burkina Faso,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BF,12.27,-1.74
+99d4fb3d-b156-3c87-9a2c-dfc0158b37c3,Burundi,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BI,-3.35,29.88
+fa46ec0b-4924-38c2-994a-53ef61b94039,Cambodia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KH,12.71,104.56
+820eb5b6-96ea-3a65-bc0d-b1e258dc7d81,Cameroon,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CM,5.13,12.27
+5435c69e-d3bc-35b2-a4d5-80e393e373d3,Canada,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CA,59.08,-109.43
+546c1bd3-1f98-3d06-b407-1a7319f0ca71,Canada without Alberta,"reference location, sources:  ecoinvent 3",,Canada without Alberta,61.8,-97.48
+9a0db1a8-1866-3aaa-9f25-881d425e2981,Canada without Alberta or Quebec,"reference location, sources:  ecoinvent 3",,Canada without Alberta or Quebec,63.05,-101.3
+042dd99e-b0ff-3653-814e-445ca0093427,Canada without Quebec,"reference location, sources:  ecoinvent 3.2",,ROC,62.47,-101.92
+888ae6c0-9317-341c-86a4-6bfdf09b72fa,"Canada, Alberta","reference location, sources:  ecoinvent 3",,CA-AB,55.17,-114.5
+391d04b7-aa3e-3b93-9d1f-4d14740ef5f7,"Canada, British Columbia","reference location, sources:  ecoinvent 3",,CA-BC,54.74,-124.76
+e2494db3-71b1-310e-bc75-5ff220d01c47,"Canada, Manitoba","reference location, sources:  ecoinvent 3",,CA-MB,54.92,-97.43
+aa44e6fb-24ea-30f5-9463-91346594e4e8,"Canada, New Brunswick","reference location, sources:  ecoinvent 3",,CA-NB,46.61,-66.37
+2d3a62fe-4d77-3861-9a5d-b0ba1452a7bc,"Canada, Newfoundland and Labrador","reference location, sources:  ecoinvent 3",,CA-NF,52.89,-60.52
+bef33c35-d56a-3154-a9e2-b20a11d7580f,"Canada, Northwest Territories","reference location, sources:  ecoinvent 3",,CA-NT,66.36,-119.0
+c4f314d4-d365-310d-89a0-42946be99544,"Canada, Nova Scotia","reference location, sources:  ecoinvent 3",,CA-NS,45.15,-63.32
+c290d478-7431-3b6d-8372-325203b55c32,"Canada, Nunavut","reference location, sources:  ecoinvent 3",,CA-NU,71.03,-88.84
+5bd185b8-bc04-31d4-8307-5955dc838694,"Canada, Ontario","reference location, sources:  ecoinvent 3",,CA-ON,50.43,-86.06
+24213e9e-14b7-3f9c-be7d-189643518a9d,"Canada, Prince Edward Island","reference location, sources:  ecoinvent 3",,CA-PE,46.39,-63.25
+11c42ab9-2538-3eb1-b665-6076cee71221,"Canada, Yukon","reference location, sources:  ecoinvent 3",,CA-YK,63.63,-135.49
+e7d76f14-42a7-3fc0-bec2-21a3f18683d1,Canary Islands,"reference location, sources:  ecoinvent 3",,Canary Islands,28.33,-15.67
+de3ec0aa-2234-3a1e-bee2-75bbc715c6c9,Cape Verde,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CV,15.07,-23.63
+288ea1e1-79de-3bc8-8a29-958f9857d9d1,Caribbean,"reference location, sources:  ecoinvent 3.2",,UN-CARIBBEAN,20.15,-74.91
+9e854e58-6592-3fe3-961f-e89d56220808,Cayman Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KY,19.31,-81.19
+4e29342d-9904-364e-9e25-fd3b92558e2f,Central African Republic,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CF,6.57,20.48
+41f3dc5d-9734-339d-86ad-47fe2970dfe0,Central America,"reference location, sources:  ecoinvent 3",,UN-CAMERICA,21.8,-99.25
+f60425bb-5d9d-361c-8365-b042007676c0,Central Asia,"reference location, sources:  ecoinvent 3",,Central Asia,45.91,66.48
+35c302ef-c91c-31e9-a4e6-490bbe01a06f,Central European Power Association,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,CENTREL,50.67,18.82
+8b6ba8a9-5220-3f57-8627-6e64a0f1cb40,Central and Eastern Europe,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,EEU,0.0,0.0
+f114427f-29d0-3a63-9781-f1cc950e138e,Centrally Planned Asia and China,"reference location, sources:  ILCD, GaBi",,CPA,0.0,0.0
+626726e6-0bd1-315f-b671-9a308a25b798,Chad,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TD,15.36,18.66
+161747ec-4dc9-355f-9760-195593742232,Chile,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CL,-23.38,-69.43
+7efdfc94-655a-35dc-aa3e-c85e9bb703fa,China,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CN,33.42,106.51
+4c4a60a5-a0d5-369e-ad35-c23714845ace,China Southern Power Grid,"reference location, sources:  ecoinvent 3.2",,CSG,24.56,106.46
+b89fbb5e-5b12-3fbf-84e0-dde2a1af83e7,"China, Anhui (安徽)","reference location, sources:  ecoinvent 3.2",,CN-AH,31.82,117.22
+0c3eee87-5877-3e08-bafd-45af750ca0b8,"China, Beijing (北京)","reference location, sources:  ecoinvent 3.2",,CN-BJ,40.17,116.4
+560cccf0-0b87-306f-bffd-5836e1175a7a,"China, Chongqing (重庆)","reference location, sources:  ecoinvent 3.2",,CN-CQ,30.05,107.85
+f15daa22-c911-3f89-ba04-2f020804afd5,"China, Fujian (福建)","reference location, sources:  ecoinvent 3.2",,CN-FJ,26.07,117.97
+10a33d7b-6e2e-3aa5-8dee-a126f06ae6c1,"China, Gansu (甘肃)","reference location, sources:  ecoinvent 3.2",,CN-GS,37.82,100.92
+e0da2e3f-1c41-368e-b7f1-d1aa54166975,"China, Guangdong (广东)","reference location, sources:  ecoinvent 3.2",,CN-GD,23.35,113.42
+e66b9cb6-fca6-3058-b3fc-ab1eea7e2162,"China, Guangxi (广西壮族自治区)","reference location, sources:  ecoinvent 3.2",,CN-GX,23.83,108.77
+a0e80568-b717-32ee-ac16-0fb0030b51cd,"China, Guizhou (贵州)","reference location, sources:  ecoinvent 3.2",,CN-GZ,26.81,106.87
+c7439785-e07d-3db1-a531-12b8a73fb9c2,"China, Hainan (海南)","reference location, sources:  ecoinvent 3.2",,CN-HA,19.19,109.74
+8f697344-3337-3a4d-a98b-fb261935fd20,"China, Hebei (河北)","reference location, sources:  ecoinvent 3.2",,CN-HB,39.55,116.12
+e40e7f95-3d17-3bfe-bd65-a885f2088578,"China, Heilongjiang (黑龙江省)","reference location, sources:  ecoinvent 3.2",,CN-HL,47.87,127.74
+37c4a9b5-5f7d-3238-bb72-4623cde79d2a,"China, Henan (河南)","reference location, sources:  ecoinvent 3.2",,CN-HE,33.88,113.6
+60418cbc-6847-3b06-a830-253aa9bd9dba,"China, Hubei (湖北)","reference location, sources:  ecoinvent 3.2",,CN-HU,30.97,112.26
+7bbc9d94-7ed7-3d7a-9953-f020aa8fa299,"China, Hunan (湖南)","reference location, sources:  ecoinvent 3.2",,CN-HN,27.61,111.69
+94f8eaf5-2a69-3408-a868-564ba00a53e9,"China, Inner Mongol (内蒙古自治区)","reference location, sources:  ecoinvent 3.2",,CN-NM,44.08,113.9
+1e9be3c3-b260-37d5-8199-be20ff6cc65f,"China, Jiangsu (江苏)","reference location, sources:  ecoinvent 3.2",,CN-JS,32.97,119.44
+8f93bdbf-02dd-37f2-9c94-15b7adb0520c,"China, Jiangxi (江西)","reference location, sources:  ecoinvent 3.2",,CN-JX,27.61,115.71
+5cb7fbc5-6a92-345e-9b8c-205b7d56e247,"China, Jilin (吉林)","reference location, sources:  ecoinvent 3.2",,CN-JL,43.67,126.17
+b6c0a73a-ad7d-352e-a96f-0e22769d89d5,"China, Liaoning (辽宁)","reference location, sources:  ecoinvent 3.2",,CN-LN,41.29,122.61
+fc88ecd5-d3d6-3669-a708-4b9a86e8907d,"China, Ningxia (宁夏回族自治区)","reference location, sources:  ecoinvent 3.2",,CN-NX,37.26,106.16
+8091cd9d-b8ec-3623-a5a2-5b61ea85eb98,"China, Qinghai (青海)","reference location, sources:  ecoinvent 3.2",,CN-QH,35.74,96.0
+442e473c-81d4-34e6-a31e-a13d33c939af,"China, Shaanxi (陕西)","reference location, sources:  ecoinvent 3.2",,CN-SA,35.18,108.86
+21f95e96-39a6-3597-9376-f920757c6fb3,"China, Shandong (山东)","reference location, sources:  ecoinvent 3.2",,CN-SD,36.35,118.15
+26f19341-0269-3662-9c33-6561ad91237f,"China, Shanghai (上海)","reference location, sources:  ecoinvent 3.2",,CN-SH,31.18,121.44
+61ca6a75-802d-39f2-b7b3-09767d6389e0,"China, Shanxi (山西)","reference location, sources:  ecoinvent 3.2",,CN-SX,37.57,112.28
+3ea7c4c6-7057-3b39-96e1-a3251dda63b2,"China, Sichuan (四川)","reference location, sources:  ecoinvent 3.2",,CN-SC,30.61,102.7
+267b1b52-9830-3ddd-bce9-0be0b80a70ec,"China, Tianjin (天津)","reference location, sources:  ecoinvent 3.2",,CN-TJ,39.29,117.32
+524dc282-e858-3e44-b59c-05a258bde0bd,"China, Xinjiang (新疆维吾尔自治区)","reference location, sources:  ecoinvent 3.2",,CN-XJ,41.09,85.18
+7b09132e-4f69-3321-b69f-fbaafccb926a,"China, Xizang (西藏自治区)","reference location, sources:  ecoinvent 3.2",,CN-XZ,31.69,88.1
+9825d889-e0ea-346a-8a60-09d9de7ad000,"China, Yunnan (云南)","reference location, sources:  ecoinvent 3.2",,CN-YN,24.97,101.47
+e22dbdd9-06f5-3598-accc-59c8ff842535,"China, Zhejiang (浙江)","reference location, sources:  ecoinvent 3.2",,CN-ZJ,29.17,120.07
+0bdff809-5c8b-31b3-8775-bf35547a1317,Christmas Island,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CX,-10.44,105.7
+8c37ce4b-665f-30ac-abb4-0fd2a3c43b04,Churchill Falls Generating Station,"reference location, sources:  ecoinvent 3",,Churchill Falls,53.52,-63.99
+8f775bae-e910-3a54-8541-f4a49f87b2f2,Clipperton Island,"reference location, sources:  ecoinvent 3.2",,Clipperton Island,10.29,-109.22
+e0323a90-39ad-3297-8bf5-b49550572c7c,Cocos (Keeling) Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CC,-12.17,96.83
+ab6c0400-6660-3ef2-919d-512b21dce9ab,Colombia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CO,3.9,-73.07
+f9180cb9-286c-39c4-b3a6-c793798b9ddf,Commonwealth of Independent States,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,CIS,45.81,59.08
+9b05de73-d43f-3c4e-8111-0c6bcc5312bc,Comoros,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KM,-11.75,43.33
+6e9cf3ee-f65d-3697-b96c-f33f27eb0f57,Congo,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CG,-0.05,15.98
+6865aeb3-a9ed-38f9-a79e-c454b259e5d0,"Congo, the Democratic Republic of the","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CD,-2.87,23.65
+d5a5b3dd-1ccb-30d3-8360-f0c068fd43fc,Cook Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CK,-21.21,-159.78
+6bb17796-0cff-3545-9414-6bd0821b4560,Coral Sea Islands,"reference location, sources:  ecoinvent 3.2",,Coral Sea Islands,-19.1,151.48
+324d8a1d-3f81-3730-9509-9a48cee0c5b6,Costa Rica,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CR,9.97,-83.94
+adab7b70-1f23-3b82-814c-8506d3dc784e,Croatia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HR,45.72,16.69
+a4dbfd6a-ef3b-3045-be61-aa0146debdf8,Cuba,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CU,21.29,-77.78
+0707ba09-2e91-360b-b05c-326e6a353593,Curaçao,"reference location, sources: ISO 3166-1, ecoinvent 3",,CW,12.19,-68.97
+471c1f3f-c1dd-3bb8-8d03-41b03e4be59e,Cyprus,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CY,35.04,33.21
+b40feb9f-0afa-3eab-9c03-5085ecbbb908,Cyprus No Mans Area,"reference location, sources:  ecoinvent 3.2",,Cyprus No Mans Area,35.1,33.25
+9c049173-fad5-34f8-9c68-231237df85b8,Czech Republic,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CZ,49.74,15.33
+35ea51ba-f1fe-3f01-82ad-5f950855dde0,Côte d'Ivoire,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CI,7.63,-5.55
+0ecbf942-6bcf-3d9a-886d-ed5fc8c4eca8,Denmark,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DK,56.05,9.26
+2a552811-5dc6-3462-a113-dda562233bd7,Dhekelia Sovereign Base Area,"reference location, sources:  ecoinvent 3.2",,Dhekelia Base,35.01,33.79
+64ca6097-2a6e-3926-91c4-b9d31080c687,Djibouti,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DJ,11.9,42.51
+608e7dc1-16de-3157-b060-12b4f0be82ac,Dominica,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DM,15.47,-61.35
+d4579b26-88d6-3523-9f40-2f6b4b43bcbf,Dominican Republic,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DO,19.01,-70.72
+c1717bc2-161f-3b18-90d6-80e24878d689,EU 15,"reference location, sources:  ILCD, GaBi",,EU-15,50.0,4.66
+80e68c50-5cf3-3f11-b809-f8cfbd9a4b17,EU 25 plus candidate countries 2005,"reference location, sources:  ILCD, GaBi",,EU-25&CC,49.0,14.51
+d5ef8373-2ea8-3c9b-9fb5-4f8cb68a9714,EU 25 plus candidate countries 2005 plus associated countries 2005,"reference location, sources:  ILCD, GaBi",,EU-25&CC&AC,0.0,0.0
+322eb489-99c8-380b-8870-87c8d2e958a2,EU 27 plus candidate countries 2007,"reference location, sources: ILCD",,EU-27&CC,0.0,0.0
+aef4c4e7-71b3-3811-876f-5a31fbf8eb0e,EU 27 plus candidate countries 2007 plus associated countries 2007,"reference location, sources: ILCD",,EU-27&CC&AC,0.0,0.0
+9813077a-1292-3b9e-9da5-bd55fa33ecb6,EU associated countries 2005,"reference location, sources:  ILCD, GaBi",,EU-AC,55.33,3.72
+b3c26978-fa5b-3e96-998d-3d5eb0cce441,EU associated countries 2007,"reference location, sources: ILCD",,EU-AC2007,0.0,0.0
+1a88a0a3-7c7f-3bac-96c8-988fe871a18d,EU candidate countries 2005,"reference location, sources:  ILCD, GaBi",,EC-CC,46.39,20.38
+0273c379-31a2-34e3-9d4a-351b4c0f4ef2,EU candidate countries 2007,"reference location, sources: ILCD",,EC-CC2007,0.0,0.0
+1981f919-7ad2-31d5-8748-b520285f6323,EU new member countries 2004,"reference location, sources:  ILCD, GaBi",,EU-NMC,48.7,20.95
+70262596-fdf2-327d-b787-12fb738a9270,EU-25,"reference location, sources:  ILCD, GaBi",,EU-25,50.52,7.59
+5c7f219e-57db-3579-a019-27fb8995651b,EU-27,"reference location, sources:  ILCD, GaBi",,EU-27,50.17,9.15
+e110324f-3d3c-3394-a6f8-f87e742dcaa4,Eastern Africa,"reference location, sources:  ecoinvent 3",,UN-EAFRICA,-5.5,37.09
+95b09ece-0ccc-3fa4-89f0-ef29d63c6dbe,Eastern Asia,"reference location, sources:  ecoinvent 3",,UN-EASIA,38.21,105.25
+db28a51a-61d7-3b0b-bb5c-a1c0a25db72e,Eastern Europe,"reference location, sources:  ecoinvent 3",,UN-EEUROPE,60.98,92.13
+2f53e6f3-f2ac-3041-a4e0-737e58c45321,Ecuador,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,EC,-1.38,-78.49
+2a6a84e9-e444-31af-bd75-cc19ce28be37,Egypt,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,EG,26.49,29.87
+74354112-1c12-3113-af80-7d1582c74bea,El Salvador,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SV,13.73,-88.86
+679f547e-8973-3198-9562-f49522f5f5ac,Electric Reliability Council of Texas,"reference location, sources: DataSmart",,ERCOT,31.1,-97.64
+b84a1ed8-db3d-3bf3-b8f4-9becdea153b2,Equatorial Guinea,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GQ,1.6,10.48
+818f9c45-cfa3-3eef-b277-ef38bcbe9910,Eritrea,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ER,16.04,38.21
+08a4415e-9d59-3ff9-a003-0b921d42b91e,Estonia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,EE,58.67,25.79
+4de1b7a4-dc53-34a8-8c25-ffb7cdb580ee,Ethiopia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ET,8.62,39.61
+d66c264e-1dbd-33e6-911d-3ffc70908e8e,Europe,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RER,54.75,15.24
+c93762d2-a7a3-335c-81c2-fa0be65506df,Europe with NORDEL (NCPA),"reference location, sources:  ecoinvent 3",,Europe with NORDEL (NCPA),54.06,29.67
+06e2458b-3178-3438-b3f4-84051244c27d,"Europe without Austria, Belgium, France, Germany, Italy, Liechtenstein, Monaco, San Marino, Switzerland, and the Vatican","reference location, sources:  ecoinvent 3.2",,RER w/o AT+BE+CH+DE+FR+IT,56.97,30.73
+817ed804-f0ed-3175-b39d-7576a1c242b1,Europe without Switzerland,"reference location, sources:  ecoinvent 3",,Europe without Switzerland,48.59,6.42
+1e11ad8e-d46d-368b-9ef5-a43e99dec543,"Europe, UN Region","reference location, sources:  ecoinvent 3",,UN-EUROPE,54.75,15.24
+73ecfbb1-f6be-3c1e-b05a-aca2cb5b216d,"Europe, without Russia and Turkey","reference location, sources:  ecoinvent 3.2",,"Europe, without Russia and Turkey",53.26,14.59
+8ebf61e1-cf59-357c-b93d-225d0ccb7181,European Network of Transmission Systems Operators for Electricity,"reference location, sources:  ecoinvent 3",,ENTSO-E,49.75,13.56
+ef1cb6e7-2d14-3b18-8cc2-41037203f60b,Falkland Islands (Malvinas),"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FK,-51.66,-58.69
+eed80702-4939-3808-883f-0031a56e9872,Faroe Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FO,62.05,-6.86
+6fac3ab6-03bb-3fb4-ae42-77786393194c,Fiji,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FJ,-17.81,177.97
+75778bf8-fde7-366d-816b-0089e7b8b793,Finland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FI,64.5,26.27
+d1e780c1-ae55-3086-82ed-b9f568342c46,Florida Reliability Coordinating Council,"reference location, sources:  ecoinvent 3",,FRCC,28.32,-81.89
+190aeb66-f132-3e93-995a-70e36f3431c5,Former Soviet Union,"reference location, sources:  ILCD, GaBi",,FSU,47.5,49.29
+82a9e4d2-6595-387a-b6e4-42391d8c5bba,France,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FR,46.56,2.55
+c4f57fe2-5b64-3193-8cfd-d118f11e9024,"France, including overseas territories","reference location, sources:  ecoinvent 3.2",,"France, including overseas territories",42.18,-2.75
+e5bb2379-7bfe-3314-a3db-43d07dbd6a74,French Guiana,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GF,3.92,-53.24
+7287aa2c-53d0-3440-9a9d-b5614937e36f,French Polynesia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PF,-17.62,-149.46
+114d6a41-5b3d-34db-b92c-a7c0da0c7a55,French Southern Territories,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TF,-49.3,69.11
+32d7508f-e692-30cb-80af-28441ef746d9,Gabon,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GA,-0.59,11.79
+92073d2f-e26e-343c-a222-cc0fb0b7d7a0,Gambia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GM,13.45,-15.38
+0ba64a0d-ea00-3479-96df-b6a66866e1ca,Georgia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GE,42.17,43.51
+5f02f088-9301-3d7b-a1ac-972c11bf3e7d,Germany,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DE,51.11,9.85
+19b19ffc-30ca-3f1c-9376-cd2982992a59,Ghana,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GH,7.96,-1.2
+28dd376c-5a44-3cc9-ae45-0ee338260c56,Gibraltar,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GI,36.13,-5.34
+56bca136-90bb-3a77-9abb-7ce558af711e,Global,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,GLO,0.0,0.0
+d692bc40-d834-33d2-8d3a-37582f58468c,Greece,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GR,39.66,21.76
+ce1d5a24-80e0-34a2-91c1-c7968cc66c13,Greenland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GL,74.71,-41.39
+a6be8a33-b7c9-37f4-bfb7-6d9c9805c7eb,Grenada,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GD,12.11,-61.67
+5343b21a-d303-3f17-9962-9894deca13db,Guadeloupe,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GP,16.28,-61.44
+d2a460df-08a4-3b7a-958f-635b540d90cb,Guam,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GU,13.38,144.7
+1bfad22f-0925-378f-b10a-37440bfdff43,Guatemala,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GT,15.25,-90.39
+73c18c59-a39b-3838-a081-ec00bb456d43,Guernsey,"reference location, sources: ISO 3166-1, ecoinvent 3",,GG,49.45,-2.57
+5123dd8b-087b-344f-9b8f-8603acd1bad4,Guinea,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GN,10.43,-10.94
+3f071f4f-163d-3855-9f4f-c1544c7f69a6,Guinea-Bissau,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GW,12.12,-14.65
+5e08be98-8691-354c-937b-997b4cb6ad97,Guyana,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GY,4.79,-58.97
+add33b5c-114e-39e1-8996-ebe46366c661,HICC,"reference location, sources:  ecoinvent 3",,HICC,20.25,-156.35
+eb5e48e7-4123-3acc-9276-1302ea4a7d22,Haiti,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HT,19.14,-72.27
+2ab5564b-805d-3065-b4bc-f81060472746,Heard Island and McDonald Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HM,-53.11,73.5
+43b1cc1d-b7be-33d8-99dd-4280f578691a,Holy See (Vatican City State),"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VA,41.9,12.45
+59ca4f8b-bb97-33c2-ab59-db115fcdb664,Honduras,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HN,14.81,-86.86
+ae417185-6a75-37b6-bd51-fc0e1f95902e,Hong Kong,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HK,22.42,114.12
+18bd9197-cb1d-333b-8352-f47535c00320,Hungary,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HU,47.07,19.13
+60a4d810-df1e-3895-95b4-025bbedca798,"IAI producing Area 4 and 5, South and East Asia, without China","reference location, sources:  ecoinvent 3.2",,"IAI Area 4&5, without China",30.77,76.42
+a2a551a6-458a-3de2-a446-cc76d639a9e9,Iceland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IS,64.76,-18.48
+13b5bfe9-6f3e-3fe4-91c9-f66f4a582adf,India,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IN,21.0,78.5
+14b3773a-9228-3ca1-98e3-3d0017100d23,Indian Ocean Territories,"reference location, sources:  ecoinvent 3.2",,AUS-IOT,-10.69,104.61
+b80bb774-0288-3da1-b201-890375a60c8f,Indonesia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ID,-0.97,114.25
+d74eea48-99a6-3f9f-8bc5-27ef988ea0ff,"Iran, Islamic Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IR,32.56,54.3
+795237fd-9d10-3e63-8d19-b0db0f2fba2f,Iraq,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IQ,33.04,43.77
+25400724-d737-3b0b-a9c9-369d9af3dd21,Ireland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IE,53.17,-8.15
+73bebce3-95b6-31ef-adcf-6842fbdb4d76,Isle of Man,"reference location, sources: ISO 3166-1, ecoinvent 3",,IM,54.22,-4.52
+4605f628-f91d-321e-8b5f-9433f46e29eb,Israel,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IL,31.02,34.85
+0d149b90-e739-3297-b01c-90191ae775f0,Italy,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IT,42.7,12.8
+3da770cc-56ed-3407-b6aa-f10ad4e72b4d,Jamaica,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,JM,18.15,-77.32
+55add3d8-45bf-3d87-a9b0-949b0da49c0a,Japan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,JP,36.49,139.06
+79563e90-630a-3352-9dff-01b6638b0886,Jersey,"reference location, sources: ISO 3166-1, ecoinvent 3",,JE,49.21,-2.12
+674f3384-1e23-39ff-9d24-c85dc3b999de,Jordan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,JO,30.7,36.31
+9008f9e2-758f-38fe-920b-1765e72734d5,Kazakhstan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KZ,48.16,67.3
+25bc6654-798e-3508-ba0b-6343212a74fe,Kenya,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KE,0.53,37.85
+988287f7-a1eb-366f-bc4e-19bdbdeec7c3,Kiribati,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KI,-1.5,175.03
+26b568e4-192a-364d-9b3e-acdbd632bc2e,"Korea, Democratic People's Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KP,39.77,126.45
+dcf0d7d2-cd12-3bf4-a580-d43f29785dd3,"Korea, Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KR,36.5,128.1
+a2d8fced-03cb-3e20-af8e-1226935c9c92,Kosovo,"reference location, sources:  ecoinvent 3.2",,XK,42.57,20.87
+048685d9-6262-3854-82a1-d5bb4a14bc3b,Kuwait,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KW,29.47,47.37
+ebe86682-666f-3ab3-9a08-43ed3097e4b3,Kyrgyzstan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KG,41.46,74.55
+c9089f3c-9ada-3018-af6f-fb1ee8d6501c,Lao People's Democratic Republic,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LA,19.9,102.47
+84502834-6281-3742-9577-a349ea768503,Latin America and the Caribbean,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RLA,-10.11,-65.62
+85d1a9c4-88d7-317e-a862-91a755e5d43c,Latvia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LV,56.85,25.64
+26403ec6-d537-3a31-b63e-294b44831734,Lebanon,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LB,33.92,35.88
+44ba5ca6-5651-34f3-af19-27576dd35436,Lesotho,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LS,-29.58,28.24
+58791f32-2c1b-3c3d-a614-1788d3b8666f,Liberia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LR,6.68,-9.65
+e728b477-51c6-3559-82cb-60f97d1e4553,Libya,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LY,27.04,18.02
+d70c1e5d-44de-3a91-90eb-91ecff563578,Liechtenstein,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LI,47.15,9.55
+d91af695-8918-3f87-96a0-57c1cdf5b225,Lithuania,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LT,55.33,23.89
+3e7e122b-f08f-3843-ac96-1ba491089dc9,Luxembourg,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LU,49.77,6.08
+27c9d518-7cd2-33f8-9160-ec1ed2b5ac89,Macao,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MO,22.2,113.54
+07d93568-0b65-31b2-a42f-e4baea021389,"Macedonia, The Former Yugoslav Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MK,41.59,21.69
+b351bb9b-0af6-34fc-a787-49675c53ad67,Madagascar,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MG,-19.37,46.7
+38fed710-7cee-3580-98ca-06304c1beb90,Malawi,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MW,-13.4,33.8
+6864f389-d987-3436-bc87-78ff071d1b6c,Malaysia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MY,4.2,102.19
+94d03594-5b3d-3218-a669-c4d3f6daa104,Maldives,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MV,3.54,72.92
+9830e1f8-1f62-3b33-906a-cc186b93374e,Mali,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ML,17.35,-3.52
+710998fd-1b7c-3235-9702-65650770a4b1,Malta,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MT,35.89,14.44
+ed8f5b7e-7439-3143-b43a-93dc753618ae,Marshall Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MH,7.59,168.96
+1d8a4975-693e-31eb-9ca5-4878098d608f,Martinique,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MQ,14.65,-61.02
+d9394066-970e-34ae-a52f-d0347e58c03e,Mauritania,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MR,20.26,-10.33
+89aa4b19-6b48-38a1-ba65-49bb1eaebd80,Mauritius,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MU,-20.25,57.58
+fa0ed5b5-c600-345b-9d9a-299952b99651,Mayotte,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,YT,-12.77,45.15
+9c7e385f-c425-3258-a571-a94454d24b2b,Melanesia,"reference location, sources:  ecoinvent 3",,UN-MELANESIA,-7.79,147.87
+3d26b0b1-7065-32cf-a9c0-6c010184c684,Mexico,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MX,23.95,-102.53
+11a4769f-1f94-3ef6-9be6-a120cd4e3e67,Micronesia,"reference location, sources:  ecoinvent 3",,UN-MICRONESIA,7.54,94.38
+0ab34ca9-7d99-3659-9bf8-9817789cb5de,"Micronesia, Federated States of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FM,6.88,158.23
+e71864bf-656a-3133-8489-a428120c0ada,Middle Africa,"reference location, sources:  ecoinvent 3",,UN-MAFRICA,0.63,19.47
+4b24ca1d-6a54-335b-811e-38a32aaa0967,Middle East,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RME,28.54,48.66
+483bbc62-bf06-31a1-9aca-efa0a24e2f1e,Middle East and North Africa,"reference location, sources:  ILCD, GaBi",,MEA,28.63,34.24
+cda0fd29-18d1-3e20-ac87-1ed79a8d2bb0,Midwest Reliability Organization,"reference location, sources:  ecoinvent 3",,MRO,50.58,-99.64
+8ce8d793-183f-312a-a33c-5c61ec31edb6,Midwest Reliability Organization (USA),"reference location, sources:  ecoinvent 3",,Midwest Reliability Organization (USA),44.82,-96.82
+793914c9-c583-39d8-ad0f-4ed8c521b0c1,"Moldova, Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MD,47.19,28.59
+d6fd0924-e324-3506-a9ae-0295adf59567,Monaco,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MC,43.75,7.41
+41256636-7c67-348b-999d-1b7666f8ccfc,Mongolia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MN,46.05,102.87
+ab86a1e1-ef70-3ff9-b959-067b723c5c24,Montenegro,"reference location, sources: ISO 3166-1, ecoinvent 3",,ME,42.79,19.25
+ee33e909-372d-335d-990f-4fcb2a92d542,Montserrat,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MS,16.73,-62.18
+b74df323-e393-3b56-b635-a2cba7a7afba,Morocco,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MA,32.7,-5.75
+4f3dd0ff-b3e4-3c5f-b4b5-b0d8c1f10bb5,Mozambique,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MZ,-14.42,37.92
+b3cd915d-7580-38bd-99d0-f2428fbb354a,Myanmar,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MM,21.71,96.04
+6ec66e12-4fb9-3c19-8e92-07b0b82f542a,Namibia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NA,-22.13,17.21
+0ab3e5d0-801a-3a3f-b758-bcbd812e8f10,Nauru,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NR,-0.52,166.93
+40590d3d-1a34-3650-81f5-e48b08ef2096,Near East,"reference location, sources:  ILCD, GaBi",,RNE,33.72,39.81
+cf3fc916-339b-32ad-9c14-aca2425ccf53,Nepal,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NP,28.25,83.93
+1a13105b-7e4e-35fb-ae7c-9515ac06aa48,Netherlands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NL,52.07,5.38
+18b049cc-8d85-3578-b929-df716f9f4e68,Netherlands Antilles,"reference location, sources:  ILCD, GaBi",,AN,12.12,-68.87
+1e734284-5e24-3b3b-9b35-54490da1c128,New Caledonia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NC,-21.35,165.44
+5c0f2c74-2dc9-3fce-b75d-086e7412f81f,New South Wales,"reference location, sources:  ecoinvent 3.2",,AUS-NSW,-32.16,147.01
+c97b334f-fd41-3a49-9708-3f1949632bc1,New Zealand,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NZ,-42.63,172.23
+e6c151d4-49e1-3b05-b1ff-b5ad5ec656cf,Nicaragua,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NI,12.84,-85.03
+d4f91763-3649-33c4-bc7a-b917fa990146,Niger,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NE,17.42,9.39
+66e10e9f-f65e-3479-a54d-de3968d3440d,Nigeria,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NG,9.59,8.1
+0288bde0-c2d5-33f2-b576-6f61b826a650,Niue,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NU,-19.05,-169.86
+4205164e-e2e5-30d6-98fb-7657af40aed6,Nordic Countries Power Association,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,NORDEL,63.76,18.88
+78d9238c-1a21-3c8b-be8f-6c26172fb12d,Norfolk Island,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NF,-29.03,167.95
+16096b94-483a-3671-b7a2-16db4118f8df,North American Free Trade Agreement,"reference location, sources:  ecoinvent 3",,NAFTA,53.42,-104.01
+588c9ca2-d66d-3e43-b7b3-65bfd7e971cf,Northeast Power Coordinating Council,"reference location, sources:  ecoinvent 3",,NPCC,51.25,-76.32
+f9d758b6-d15e-3238-aa0e-e0a3b949fc32,Northern Africa,"reference location, sources:  ecoinvent 3",,UN-NAFRICA,23.88,15.96
+b320e7db-c758-3ba6-8839-81eb83c9d7d7,Northern America,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RNA,58.71,-91.96
+bd6ef2ee-f612-38be-bce0-90c8e64ebaa9,Northern Cyprus,"reference location, sources:  ecoinvent 3.2",,Northern Cyprus,35.27,33.59
+da657f65-6f70-3a48-893f-64cf7be37d09,Northern Europe,"reference location, sources:  ecoinvent 3",,UN-NEUROPE,63.06,13.8
+1f2dfa56-7dcf-3583-bedd-f7aec167fec7,Northern Mariana Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MP,15.0,145.62
+4382e0b4-8ddb-3600-bf3d-10de8fabfb86,Northern Territory,"reference location, sources:  ecoinvent 3.2",,AUS-NTR,-19.41,133.36
+7fa3b767-c460-354a-abe4-d49030b349c7,Norway,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NO,61.15,8.74
+61c8d2f5-500d-37c3-a13e-4ed176dcf6d2,Oceania,"reference location, sources:  ecoinvent 3",,UN-OCEANIA,-25.28,136.4
+6aa2b79b-1fc3-384c-b1af-565b51d5e4ad,Oceanic,"reference location, sources:  ILCD, GaBi",,OCE,0.0,0.0
+d58da822-8993-3d8c-8ec4-f40689c2847e,Oman,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,OM,21.65,57.4
+cd0acfe0-85ee-30f8-b439-1fb9b8009bed,Other Pacific Asia,"reference location, sources:  ILCD, GaBi",,PAS,12.39,123.83
+655ae040-aec1-37f7-8d79-0580c5ac37ab,"Pacific OECD (Japan, Australia, New Zealand)","reference location, sources:  ILCD, GaBi",,PAO,-9.99,148.97
+1cd3c693-132f-3c31-b5b5-e5f4c5eed6bd,Pakistan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PK,29.96,69.38
+8fe4c114-5128-3c09-8a65-78e6ddbf5eed,Palau,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PW,7.5,134.57
+8812c36a-a5ae-336c-aa77-bf63211d899a,"Palestinian Territory, Occupied","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PS,32.03,35.27
+e529a9ce-a4a7-38eb-9c58-28b13b22844c,Panama,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PA,8.38,-80.92
+235ec523-92b7-3977-939c-f78b62e708d3,Papua New Guinea,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PG,-5.94,143.45
+dfed5bc1-77b8-3ab3-97c5-84e06566adc6,Paraguay,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PY,-23.23,-58.39
+dd07de85-6139-3a7c-b7f8-fcc1752d45e1,Peru,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PE,-9.32,-75.55
+da984e42-a589-3bbd-ac49-6ef0cbadcee2,Philippines,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PH,11.11,122.46
+ded0804c-f804-36d2-ae37-953dc2dbc505,Pitcairn,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PN,-24.36,-128.31
+28840420-4e3d-3522-a930-8317344a285d,Poland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PL,52.12,19.4
+b9b1f592-541c-3b02-bd41-1f6ea05a6ea5,Polynesia,"reference location, sources:  ecoinvent 3",,UN-POLYNESIA,-15.29,-158.9
+fc9fdf08-4e29-3f26-a270-390dc49061a2,Portugal,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PT,40.3,-8.05
+64e1e1cb-e1ca-3e88-af3a-838a3e7b57d6,Puerto Rico,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PR,18.22,-66.46
+8264ee52-f589-34c0-991a-a94f87aa1aeb,Qatar,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,QA,25.31,51.19
+ceaa2d09-0b6e-398c-98b3-41c15d7db178,Queensland,"reference location, sources:  ecoinvent 3.2",,AUS-QNS,-22.57,144.55
+1e2bf244-82a6-36c2-9374-13eae0aeac38,Québec,"reference location, sources:  ecoinvent 3",,Québec,53.39,-71.75
+6c68ef81-a341-3ab2-bc21-e280c511bd86,"Québec, HQ distribution network","reference location, sources:  ecoinvent 3",,"Québec, HQ distribution network",50.49,-72.38
+1560a2df-f599-3750-9974-8cbda44b4c51,ReliabilityFirst Corporation,"reference location, sources:  ecoinvent 3",,RFC,40.81,-82.23
+f1965a85-7bc2-35d2-afe2-2023aa5ab50d,Rest-of-World,"reference location, sources:  ecoinvent 3",,RoW,0.0,0.0
+3605c251-087b-3821-ac9b-ca890e07ad9c,Romania,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,RO,45.84,24.96
+7d199e42-c733-3c12-87e1-ce5672f33ae6,Russia (Asia),"reference location, sources:  ecoinvent 3.2",,Russia (Asia),62.73,110.63
+84c26536-0d12-33e3-8ed0-e7fa435f9a45,Russia (Europe),"reference location, sources:  ecoinvent 3.2",,Russia (Europe),59.24,45.62
+89484b14-b36a-3d53-a942-6a3d944d2983,Russian Federation,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,RU,61.84,97.03
+038c0dc8-a958-3fea-97af-047244fb6960,Rwanda,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,RW,-1.99,29.91
+12eccbdd-9b32-3181-b134-1f38907cbbb5,Réunion,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,RE,-21.12,55.53
+44193271-0d3b-309d-b869-820f52c4c6db,SERC Reliability Corporation,"reference location, sources:  ecoinvent 3",,SERC,34.99,-86.47
+fd18772c-bac1-3277-b20d-cccc1b90efb9,Saint Barthélemy,"reference location, sources: ISO 3166-1, ecoinvent 3",,BL,18.04,-63.04
+77cbc257-e663-3286-acf6-191754c0c8e3,"Saint Helena, Ascension and Tristan da Cunha","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SH,-15.95,-5.71
+8c7e6965-b416-3689-a88b-313bbe7450f9,Saint Kitts and Nevis,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KN,17.34,-62.76
+196accbc-f32b-3a8e-abef-92e1a37d0fc0,Saint Lucia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LC,13.89,-60.96
+ea81aa7d-f47d-34c6-b37b-f98fabf3ff82,Saint Martin (French part),"reference location, sources: ISO 3166-1, ecoinvent 3",,MF,18.09,-63.04
+5109d85d-95fe-3e78-96d9-704e6e5b1279,Saint Pierre and Miquelon,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PM,47.04,-56.32
+c56e5259-4d4e-3e7f-acb2-b96c4637b486,Saint Vincent and the Grenadines,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VC,13.24,-61.19
+742523da-ef59-3b4b-b184-09f46de05d0c,Samoa,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,WS,-13.65,-172.41
+ed79acb0-cd3d-3f83-a0c5-3c7798335ef0,San Marino,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SM,43.94,12.46
+627fcdb6-cc9a-3e16-9657-ca6cdef0a6bb,Sao Tome and Principe,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ST,0.2,6.62
+6108d9a8-6ab3-3a57-b470-a194c15a1d16,Saskatchewan,"reference location, sources:  ecoinvent 3",,CA-SK,54.41,-105.88
+c12e01f2-a13f-3558-be1e-9e4aedb8242d,Saudi Arabia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SA,24.02,44.58
+d0ea3a63-8908-3b86-a4f9-10b6170de942,Scarborough Reef,"reference location, sources:  ecoinvent 3.2",,Scarborough Reef,15.15,117.75
+afbe94cd-be69-393e-babc-9f1325fc7dff,Senegal,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SN,15.01,-14.88
+3a2d7564-baee-3918-aebc-7b65084aabd1,Serbia,"reference location, sources: ISO 3166-1, ecoinvent 3",,RS,44.03,20.8
+95cc64dd-2825-39df-93ec-4ad683ecf339,Serbia and Montenegro,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,CS,43.86,20.59
+cc9dabdf-852c-3698-ae98-b3d1d8b1c324,Serranilla Bank,"reference location, sources:  ecoinvent 3.2",,Serranilla Bank,15.86,-78.63
+d54185b7-1f61-3c30-a396-ac4bc44d3269,Seychelles,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SC,-4.64,55.47
+5f507fb0-b905-3a32-bb57-967d0a3b3b43,Siachen Glacier,"reference location, sources:  ecoinvent 3.2",,Siachen Glacier,35.39,77.17
+54a2bf8c-09ac-367d-b513-aaa1aa7aa0f3,Sierra Leone,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SL,8.56,-11.79
+5dae4296-88af-3c52-9ad8-7ac394192c6d,Singapore,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SG,1.35,103.8
+2c38b9e4-5cec-3b32-8dde-4e3d5b22c648,Sint Maarten (Dutch part),"reference location, sources: ISO 3166-1, ecoinvent 3",,SX,12.56,-68.33
+41d6ad07-61a5-327a-9e1b-d567041ce9e9,Slovakia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SK,48.7,19.49
+ac5585d9-8646-3255-a99c-359140537783,Slovenia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SI,46.12,14.82
+26148d62-1ef7-3844-918a-f182d63976b6,Solomon Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SB,-9.61,160.1
+b807023f-87e6-3b8a-9a92-f79f546ff9cc,Somalia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SO,9.77,48.31
+4f146d3d-de5e-3896-8bac-17f57c9eaa05,Somaliland,"reference location, sources:  ecoinvent 3.2",,Somaliland,9.73,46.25
+959848ca-10cc-3a60-9a81-8ac11523dc63,South Africa,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ZA,-30.55,23.12
+d34c6aba-144a-3e2d-acb4-0dd5f93ae50e,South America,"reference location, sources:  ecoinvent 3",,UN-SAMERICA,-15.03,-60.73
+1494adfb-98f4-3dc3-83b2-10bead2efff7,South Australia,"reference location, sources:  ecoinvent 3.2",,AUS-SAS,-30.1,135.82
+1d8d5e91-2302-308b-9e88-c3e77fcad378,South Georgia and the South Sandwich Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GS,-54.2,-36.89
+3691308f-2a4c-3f69-83f2-880d32e29c84,South Sudan,"reference location, sources: ISO 3166-1, ecoinvent 3",,SS,7.3,30.25
+e832ff92-78c2-3ab2-8f7d-d0ca126994bf,South-Eastern Asia,"reference location, sources:  ecoinvent 3",,UN-SEASIA,7.93,109.93
+326dde39-0b64-3523-b09f-aa0f427066d8,Southern Africa,"reference location, sources:  ecoinvent 3",,UN-SASIA,-25.49,22.53
+a8a64cef-262a-34de-8872-b68b63ab7cd8,Southern Asia,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,SAS,7.93,109.93
+fe8f0f22-0c96-348b-86c2-b27e42d27f04,Southern Europe,"reference location, sources:  ecoinvent 3",,UN-SEUROPE,41.48,7.31
+5566919c-eb38-3560-957c-4fddbf8314c7,Southwest Power Pool,"reference location, sources:  ecoinvent 3",,SPP,36.18,-97.9
+12470fe4-06d4-3017-996e-ab37dd65fc14,Spain,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ES,40.22,-3.64
+e914aa2b-6272-3660-9305-a03124b4d9a8,Spratly Islands,"reference location, sources:  ecoinvent 3.2",,Spratly Islands,10.54,114.92
+d0fa06cd-9333-3c8c-ae35-7ffe5cd1c4e9,Sri Lanka,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LK,7.61,80.7
+6515e168-6762-351f-b146-9deb97414906,State Grid Corporation of China,"reference location, sources:  ecoinvent 3.2",,SGCC,37.81,103.55
+748ced3d-d3ad-3822-bb8f-2e73f28ef722,Sub-Sahara Africa,"reference location, sources:  ILCD, GaBi",,AFR,-1.23,18.32
+6226f7cb-e59e-39a9-8b5c-ef6f94f966fd,Sudan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SD,15.98,29.93
+e22428cc-f96c-3a96-b4a9-39c209ad1000,Suriname,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SR,4.12,-55.91
+b5bf27b2-555d-344e-bdf2-230080db5a1d,Svalbard and Jan Mayen,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SJ,78.82,18.37
+7dabf5c1-98b0-3ab2-aaa4-2bb03a113e55,Swaziland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SZ,-26.56,31.49
+efad7abb-323e-3d40-9628-4c8a6da076a1,Sweden,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SE,62.01,15.27
+d88fc6ed-f21e-3464-935f-f76288b84103,Switzerland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CH,46.86,7.9
+1548af1c-94ad-3558-8324-df8f08baf227,Syrian Arab Republic,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SY,35.01,38.5
+255a5cac-7685-3722-b4d0-2f04c37be771,"Taiwan, Province of China","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TW,23.75,120.94
+456c2e75-fe0f-3a57-bd1c-fd87117e0963,Tajikistan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TJ,38.66,69.42
+73bb4387-b307-3739-aacb-9cd62ac4049c,"Tanzania, United Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TZ,-6.27,34.82
+5bb22373-e69e-31fe-b00e-0a38a7129c8c,Tasmania,"reference location, sources:  ecoinvent 3.2",,AUS-TSM,-41.93,146.59
+7e764aa6-b752-3530-855f-0373606d1886,Texas Regional Entity,"reference location, sources:  ecoinvent 3",,TRE,30.91,-99.21
+1fdc0f89-3412-3e55-b0d2-811821b84d3b,Thailand,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TH,15.7,100.84
+313a21d5-badc-3f56-b223-8ebf8c7690f6,Timor-Leste,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TL,-8.82,125.87
+1f0eb098-5870-335e-a2fa-2f68a223b173,Togo,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TG,8.79,1.08
+b6717b91-c759-3cc0-bf30-aa9a784e6390,Tokelau,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TK,-9.19,-171.85
+01b6e203-44b6-3835-85ed-1ddedf20d531,Tonga,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TO,-21.2,-175.18
+accc9105-df53-3311-9407-fd5b41255e23,Trinidad and Tobago,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TT,10.46,-61.25
+aafb96b2-fa88-36be-b07c-4496867bad56,Tunisia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TN,35.38,9.59
+e7d707a2-6e7f-3b6f-b52c-489c60e429b1,Turkey,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TR,39.06,35.17
+6a962563-e235-3178-9e66-3e356ac8d9e4,Turkmenistan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TM,39.12,59.38
+5c4fefda-27cf-384c-b999-be13e6b8608a,Turks and Caicos Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TC,21.9,-71.95
+c9a1fdac-6e08-3dd8-9e71-73244f34d7b3,Tuvalu,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TV,-8.51,179.21
+e743b51e-41f8-3369-9418-34177c8f34e7,UCTE without France,"reference location, sources:  ecoinvent 3",,UCTE without France,46.03,12.52
+cdba052d-e53c-3173-b857-3d555fad2c16,UCTE without Germany,"reference location, sources:  ecoinvent 3",,UCTE without Germany,45.45,10.92
+8dc6a685-44c9-3a1c-b937-78a6de2d9830,UCTE without Germany and France,"reference location, sources:  ecoinvent 3",,UCTE without Germany and France,45.18,12.88
+aae773f6-9106-3fd9-95d0-c38764e6dccd,US Naval Base Guantanamo Bay,"reference location, sources:  ecoinvent 3.2",,Guantanamo Bay,19.92,-75.15
+2a0617ac-cf8b-3862-9c43-e2ffeb5b8d5b,Uganda,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,UG,1.28,32.38
+5269f4d7-5f5b-375f-8f94-bab2100a5531,Ukraine,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,UA,49.01,31.38
+b633c174-f67b-3819-a2a4-ef89f2d5b8cb,Union for the Co-ordination of Transmission of Electricity,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,UCTE,46.09,10.8
+b6bb43df-4525-3928-a105-fb5741bddbea,United Arab Emirates,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AE,23.54,54.16
+7885444a-f42e-3b30-8518-c5be17c8850b,United Kingdom,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GB,53.0,-1.6
+0b3b97fa-6688-3c56-88ee-4ae80ec0c3c2,United States,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,US,39.62,-98.6
+0dd00e33-b6fc-37b8-91eb-e3177217d6c0,United States Minor Outlying Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,UM,-0.38,-160.02
+c385c23d-66c3-3558-989c-db5586384532,"United States, Alabama","reference location, sources: USDA, DataSmart",,US-AL,32.79,-86.8
+b423ff37-b678-3ea4-9366-ede7b1a7c0c0,"United States, Alaska","reference location, sources: DataSmart",,US-AK,61.38,-152.26
+b7745632-fc6d-37f8-85f0-f53c48027b96,"United States, Arizona","reference location, sources: USDA, DataSmart",,US-AZ,33.77,-111.38
+b54bf461-c111-318c-9f92-a499f34dc05d,"United States, Arkansas","reference location, sources: USDA, DataSmart",,US-AR,34.95,-92.38
+b775ab58-2693-342d-b496-3265a17b5b32,"United States, California","reference location, sources: USDA, DataSmart",,US-CA,36.17,-119.74
+12fe7ead-4836-3c05-bbd9-768e2f0fdb66,"United States, Colorado","reference location, sources: USDA, DataSmart",,US-CO,39.06,-105.32
+e86115dd-61e0-3652-8b8f-79fc693dcf01,"United States, Connecticut","reference location, sources: DataSmart",,US-CT,41.58,-72.76
+1ae4da05-1c10-36a3-aadc-da3431d1b677,"United States, Delaware","reference location, sources: USDA, DataSmart",,US-DE,39.34,-75.51
+efe104ea-d72b-3371-940f-1bb877257ab3,"United States, District of Columbia","reference location, sources: DataSmart",,US-DC,38.89,-77.02
+445fe89e-beea-3ff9-8975-167f35b53373,"United States, Florida","reference location, sources: USDA, DataSmart",,US-FL,27.83,-81.71
+2b701fc6-ef0e-3b9a-9f4d-631863e904f6,"United States, Georgia","reference location, sources: USDA, DataSmart",,US-GA,32.98,-83.64
+fe2bd352-e70f-3e48-a023-02843b5ac978,"United States, Hawaii","reference location, sources: DataSmart",,US-HI,21.1,-157.53
+1f80437b-a9fb-34e0-a052-26a2a7fd5520,"United States, Idaho","reference location, sources: USDA, DataSmart",,US-ID,44.23,-114.51
+c2521c9e-e466-3960-b789-4046cadadf24,"United States, Illinois","reference location, sources: USDA, DataSmart",,US-IL,40.33,-89.0
+70f8ca91-42c2-3bae-a4e2-dcc1b8033abe,"United States, Indiana","reference location, sources: USDA, DataSmart",,US-IN,39.86,-86.26
+fa384517-d567-36e2-9a5a-dd52df663dcf,"United States, Iowa","reference location, sources: USDA, DataSmart",,US-IA,42.0,-93.21
+d9c55cbc-3e12-3ff1-9370-bdfebddccd5f,"United States, Kansas","reference location, sources: USDA, DataSmart",,US-KS,38.51,-96.8
+e132e45b-712d-3e2c-af19-c1f1b99c3c91,"United States, Kentucky","reference location, sources: USDA, DataSmart",,US-KY,37.66,-84.65
+c384a41a-bbea-3bc9-b333-75287ddb64bb,"United States, Louisiana","reference location, sources: USDA, DataSmart",,US-LA,31.18,-91.87
+4d844119-4127-3a4d-b856-663e8039d21c,"United States, Maine","reference location, sources: DataSmart",,US-ME,44.6,-69.39
+86596f8c-55cb-3a71-976f-6a56e871f29b,"United States, Maryland","reference location, sources: USDA, DataSmart",,US-MD,39.07,-76.79
+85a8277c-cb62-3889-ae66-71d05d9263d3,"United States, Massachusetts","reference location, sources: DataSmart",,US-MA,42.23,-71.53
+bb966cd1-e1ba-33fd-8375-56d66970d7df,"United States, Michigan","reference location, sources: USDA, DataSmart",,US-MI,43.35,-84.56
+7aa1c4da-339b-3230-8838-2de0f6a6581a,"United States, Minnesota","reference location, sources: USDA, DataSmart",,US-MN,45.73,-93.91
+0ee63262-59b9-3da8-8cf7-5f42828ffa7b,"United States, Mississippi","reference location, sources: USDA, DataSmart",,US-MS,32.76,-89.68
+cdc9423a-0890-3494-b717-51263425bcf6,"United States, Missouri","reference location, sources: USDA, DataSmart",,US-MO,38.46,-92.3
+a220b227-87c9-368d-8bfe-5ff357517419,"United States, Montana","reference location, sources: USDA, DataSmart",,US-MT,46.9,-110.32
+669eb22e-cf87-3b59-a553-06880eed6a5a,"United States, Nebraska","reference location, sources: USDA, DataSmart",,US-NE,41.12,-98.28
+f9eab7a5-2fbd-36f4-b88f-438ba1a8da94,"United States, Nevada","reference location, sources: DataSmart",,US-NV,38.41,-117.12
+ca2b1447-f5e7-3554-b244-ee56ce0e92ff,"United States, New Hampshire","reference location, sources: DataSmart",,US-NH,43.41,-71.56
+52c1fc37-d9e9-33a1-aaea-c2bc601b0364,"United States, New Jersey","reference location, sources: DataSmart",,US-NJ,40.31,-74.5
+560e664b-9150-3314-b530-1eaa6af5b067,"United States, New Mexico","reference location, sources: DataSmart",,US-NM,34.83,-106.23
+0efe3dd6-681d-3dd2-8970-52bea5982168,"United States, New York","reference location, sources: USDA, DataSmart",,US-NY,42.14,-74.93
+cf1fe73c-b3b8-3e6a-a362-a24cc00edca8,"United States, North Carolina","reference location, sources: USDA, DataSmart",,US-NC,35.64,-79.84
+7d5a6438-e66c-37d7-b069-9f6cbb9efb22,"United States, North Dakota","reference location, sources: USDA, DataSmart",,US-ND,47.53,-99.79
+8f530ffb-71ad-30e5-8e27-ea335b94166f,"United States, Ohio","reference location, sources: USDA, DataSmart",,US-OH,40.37,-82.77
+9704b0fb-3771-33d7-a07d-a7d6e1a431a2,"United States, Oklahoma","reference location, sources: USDA, DataSmart",,US-OK,35.53,-96.92
+7fb70584-7e67-3d35-9d3a-16a62784d3a3,"United States, Oregon","reference location, sources: USDA, DataSmart",,US-OR,44.56,-122.12
+22b8b398-1b5b-3955-a162-614bb67b5927,"United States, Pennsylvania","reference location, sources: USDA, DataSmart",,US-PA,40.57,-77.26
+869d2f4d-09bf-3b85-b19d-3cd046b07ac5,"United States, Rhode Island","reference location, sources: DataSmart",,US-RI,41.67,-71.51
+58a2cc24-3eaf-3596-988e-742e109b66fd,"United States, South Carolina","reference location, sources: USDA, DataSmart",,US-SC,33.81,-80.9
+112e6937-5e63-32a1-ba68-730cbd933c75,"United States, South Dakota","reference location, sources: USDA, DataSmart",,US-SD,44.28,-99.46
+1be0b149-5590-34c3-bee8-fdb3255c95f4,"United States, Tennessee","reference location, sources: USDA, DataSmart",,US-TN,35.74,-86.74
+f767f1ae-d126-3766-846d-62fa2f6f927f,"United States, Texas","reference location, sources: USDA, DataSmart",,US-TX,31.1,-97.64
+10334e82-fe92-33bf-9d45-2decb730b1c2,"United States, Utah","reference location, sources: DataSmart",,US-UT,40.11,-111.85
+3b7e10ba-fd35-381d-8ff5-8811c0f6bf32,"United States, Vermont","reference location, sources: DataSmart",,US-VT,44.04,-72.7
+4ec8c4f4-fd4d-3a38-80a5-7446f9420f11,"United States, Virginia","reference location, sources: USDA, DataSmart",,US-VA,37.76,-78.2
+9ef574c2-cd1a-3866-b782-5e74b2c6cfcb,"United States, Washington","reference location, sources: USDA, DataSmart",,US-WA,47.39,-121.57
+a8ce62fb-3610-311c-8af0-a8bf4942f5a0,"United States, West Virginia","reference location, sources: DataSmart",,US-WV,38.46,-80.96
+38af12ff-e146-3293-a429-6ddf9c28b806,"United States, Wisconsin","reference location, sources: USDA, DataSmart",,US-WI,44.25,-89.63
+373367f9-6d69-3917-ac7a-b9b523b4f30f,"United States, Wyoming","reference location, sources: DataSmart",,US-WY,42.74,-107.2
+1b23f8a4-c97c-355f-b57e-c2aae921f03d,Uruguay,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,UY,-32.8,-56.01
+8b3274b7-55aa-3339-82f5-7fb557e25923,Uzbekistan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,UZ,41.75,63.17
+0730b75e-96c0-353b-9b19-6be7ff4fa194,Vanuatu,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VU,-15.37,166.89
+eabb18f0-a40c-3b35-9237-0c9e1bc1d61e,"Venezuela, Bolivarian Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VE,7.12,-66.16
+b04ebbb9-1260-3d5b-a16f-5f2a16c4886e,Victoria,"reference location, sources:  ecoinvent 3.2",,AUS-VCT,-36.85,144.3
+5e9c52c6-d618-381e-bd9d-62a294c4979c,Viet Nam,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VN,21.49,105.31
+1815235d-384d-3912-9466-8c73298f1e52,"Virgin Islands, British","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VG,18.5,-64.48
+35b36b28-916d-38b3-8abd-df832e286126,"Virgin Islands, U.S.","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VI,17.96,-64.78
+c1b291cb-8522-336e-8217-31b509c9fcdd,Wallis and Futuna,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,WF,-13.78,-177.14
+fb033b5d-d7d0-37f5-a147-c0bfed75d56c,Western Africa,"reference location, sources:  ecoinvent 3",,UN-WAFRICA,14.74,-1.17
+02cb9a5a-488d-3ea0-84d9-3ae7b315e386,Western Asia,"reference location, sources:  ecoinvent 3",,UN-WASIA,28.46,43.36
+2ccce7fd-714d-3ce6-8a5d-909f98c8819f,Western Australia,"reference location, sources:  ecoinvent 3.2",,AUS-WAS,-25.46,122.17
+f62a6cfc-7bf3-3556-a8b3-a168accf9875,Western Electricity Coordinating Council,"reference location, sources:  ecoinvent 3",,WECC,46.6,-116.2
+27ec30d1-c271-32b7-8cdf-d39530307275,Western Europe,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,WEU,48.53,6.48
+28c494da-87ff-3996-9927-ac34ba30adbe,Western Sahara,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,EH,24.55,-13.7
+00c66f1a-036b-38f9-8b70-9cb8d925d3d9,Yemen,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,YE,15.8,48.35
+d9c29677-6530-3ff5-92a5-ab979ed1f7a0,Zambia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ZM,-14.61,26.32
+a1555463-c361-3703-aa27-4a8b44e29192,Zimbabwe,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ZW,-19.0,29.87
+9cea1e24-73aa-3499-95fa-34faac95b3e7,Åland Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AX,60.19,19.95

--- a/refdata/locations.csv
+++ b/refdata/locations.csv
@@ -1,473 +1,570 @@
 ID,Name,Description,Category,Code,Latitude,Longitude
-af92823f-638d-36d7-8406-451a58f61543,"AI producing Area 2, North America, without Quebec","reference location, sources:  ecoinvent 3",,"IAI Area 2, without Quebec",55.96,-91.69
-f0357a3f-154b-32ff-a2bf-f55055457068,Afghanistan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AF,33.67,65.21
-0d0ac1d0-76ad-307d-8b0e-05f06c746da9,Africa,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RAF,6.41,18.28
-9ebe579b-1c4d-361f-97a7-4d7f59fcb7a6,Akrotiri Sovereign Base Area,"reference location, sources:  ecoinvent 3.2",,Akrotiri,34.63,32.93
-31c68c64-6657-3dcc-bc06-2d977c76315b,"Al producing Area 1, Africa","reference location, sources:  ecoinvent 3",,IAI Area 1,-2.34,22.31
-cf7ec575-43e5-3274-8c54-1e9ec72461bd,"Al producing Area 2, North America","reference location, sources:  ecoinvent 3",,"Al producing Area 2, North America",55.13,-103.95
-8364be66-e49f-36e8-8ea4-a8795d469fe3,"Al producing Area 3, South America","reference location, sources:  ecoinvent 3",,IAI Area 3,-15.98,-57.19
-bf69fffd-74b6-38ce-8f6d-ceb50bafc212,"Al producing Area 6A, West Europe","reference location, sources:  ecoinvent 3",,IAI Area 6A,52.13,6.08
-6283d7a2-fe9b-303e-bb10-35a6cba0804d,"Al producing Area 6B, East/Central Europe","reference location, sources:  ecoinvent 3",,IAI Area 6B,61.28,92.9
-a335f1f7-79cd-311f-b82e-33648aa17cd3,"Al producing Area 8, Gulf-Aluminium Council/Gulf Region","reference location, sources:  ecoinvent 3",,IAI Area 8,21.35,55.61
-d9a20693-e28e-33ac-aa03-8df3b3bfa273,Alaska Systems Coordinating Council,"reference location, sources:  ecoinvent 3",,ASCC,60.53,-143.14
-97282b27-8e5d-3186-af8e-57204e4820e5,Albania,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AL,41.14,20.06
-0de7b6a6-1a70-388b-a6e6-eeb3113531a3,Algeria,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DZ,28.16,2.63
-a2788633-a453-37e8-ac1d-c6c5b63300b2,"Aluminium producing area, EU27 and EFTA countries","reference location, sources:  ecoinvent 3.2",,"IAI Area, EU27 & EFTA",53.93,8.96
-15b95f69-f97e-36b9-a54e-905eff9c2bdb,"Aluminium producing area, Europe outside EU27 and EFTA","reference location, sources:  ecoinvent 3.2",,"IAI Area, Europe outside EU & EFTA",61.93,96.49
-f970e276-7d0c-3e75-876e-a857f92e319b,American Samoa,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AS,-14.31,-170.73
-6b356dcf-86c7-3e74-826f-3ae5725687d3,Americas,"reference location, sources:  ecoinvent 3",,UN-AMERICAS,35.54,-83.1
-523af537-946b-39c4-b836-9ed39ba78605,Andorra,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AD,42.54,1.57
-adac5e63-f80f-3629-a957-3527b25891d3,Angola,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AO,-12.29,17.54
-4921c0e2-d1f6-305a-be1f-9ec2e2041909,Anguilla,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AI,18.23,-63.03
-b2b04af9-f8f3-3b06-a29e-03ac8d3c24ca,Antarctica,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AQ,-80.44,21.3
-4e42f7dd-43ec-3fe1-84de-58610557c5ba,Antigua and Barbuda,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AG,17.07,-61.78
-c582dec9-43ff-3b74-baa0-691df291cea6,Argentina,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AR,-35.37,-65.16
-c04cd38a-eb30-33ad-9f8a-b4e64a0ded7b,Armenia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AM,40.53,44.56
-b787d22d-9cb0-3342-a58b-f546039117bc,Aruba,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AW,12.51,-69.97
-bc388e13-830e-35bd-8be3-d90b027ac5ad,Ashmore and Cartier Islands,"reference location, sources:  ecoinvent 3.2",,AUS-AC,-12.43,123.58
-1c280670-4821-3d48-b168-efc6d6685406,Asia,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RAS,45.2,96.07
-9331c8d7-3b48-3a8f-a4a8-2ea976840ba9,Asia without China,"reference location, sources:  ecoinvent 3.2",,Asia without China,47.17,94.01
-e39deabc-78c0-37a0-a5dd-30a225aa9eec,"Asia, UN Region","reference location, sources:  ecoinvent 3",,UN-ASIA,32.22,84.57
-8bcc25c9-6aa5-371f-ba76-309077753e67,Australia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AU,-24.97,136.18
-05b093bc-7b17-3c30-a09d-1c41f13e009a,Australia and New Zealand,"reference location, sources:  ecoinvent 3",,UN-AUSTRALIANZ,-26.38,135.98
-3e91fecc-17db-3393-ad8f-0e2c0131053d,Australian Capital Territory,"reference location, sources:  ecoinvent 3.2",,AUS-ACT,-35.49,149.0
-7d0db380-a5b9-3a8b-a1da-0bca241abda1,Austria,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AT,47.68,14.91
-cc8c0a97-c2df-3d73-8aff-160b65aa39e2,Azerbaijan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AZ,40.43,47.39
-7c9df801-238a-3e28-8ae2-675fd3166a1a,Bahamas,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BS,24.62,-78.01
-c08bba7a-0c03-36f1-951e-8474d853ecbf,Bahrain,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BH,26.01,50.56
-cfd7a475-f752-3ef8-95e8-d042c4511dd3,Bajo Nuevo Bank (Petrel Is.),"reference location, sources:  ecoinvent 3.2",,Bajo Nuevo,15.81,-79.83
-b380c952-746f-3cf9-89ae-d6562c7ee132,Baltic System Operator,"reference location, sources:  ecoinvent 3",,BALTSO,56.81,24.72
-c419b06b-4c65-39b5-8ff0-5adb3b8424f1,Bangladesh,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BD,24.21,89.94
-21ad0bd8-36b9-3d08-b4cf-640b4c298e7c,Barbados,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BB,13.15,-59.55
-df3f079d-e696-3496-b046-0dcfdbf9bca3,Belarus,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BY,53.54,28.04
-910955a9-07e7-39b8-9ec8-855763108a29,Belgium,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BE,50.64,4.66
-b005ad12-9444-3268-8084-f19bf5e19729,Belize,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BZ,17.21,-88.6
-39b9df3a-0fb3-356d-91a6-3e22260e96ab,Benin,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BJ,10.54,2.46
-08424385-5820-39ca-87f4-66f645784636,Bermuda,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BM,32.33,-64.7
-69206263-69b1-3058-84f5-e3d6f93b5f6e,Bhutan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BT,27.41,90.42
-ad7532d5-b386-3a40-8fbe-01f9455dca36,"Bolivia, Plurinational State of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BO,-16.71,-64.67
-52196aa5-4f16-34f9-acbf-26439c42c763,"Bonaire, Sint Eustatius and Saba","reference location, sources: ISO 3166-1, ecoinvent 3",,BQ,12.56,-68.33
-07159c47-ee1b-39ae-8fb9-c40d480856c4,Bosnia and Herzegovina,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BA,44.16,17.78
-823355b6-3ab3-3f0a-8e4d-1367e89abd1c,Botswana,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BW,-22.18,23.81
-121aa3ee-4a7d-3b1b-bbc7-60fd0c6de79b,Bouvet Island,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BV,-54.42,3.41
-dc634e20-7282-3fe0-b5be-9a2063390544,Brazil,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BR,-10.77,-53.08
-f98ed07a-4d5f-30f7-9e14-10d905f1477f,British Indian Ocean Territory,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IO,-7.33,72.41
-4e58188f-f528-3ea1-aec7-38fffc0e118d,Brunei Darussalam,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BN,4.46,114.59
-5523c88d-d347-31b7-8c61-7f632b7efdb7,Bulgaria,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BG,42.76,25.23
-c9f9d7dd-806c-3412-a041-837a80f47c64,Burkina Faso,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BF,12.27,-1.74
-99d4fb3d-b156-3c87-9a2c-dfc0158b37c3,Burundi,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,BI,-3.35,29.88
-fa46ec0b-4924-38c2-994a-53ef61b94039,Cambodia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KH,12.71,104.56
-820eb5b6-96ea-3a65-bc0d-b1e258dc7d81,Cameroon,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CM,5.13,12.27
-5435c69e-d3bc-35b2-a4d5-80e393e373d3,Canada,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CA,59.08,-109.43
-546c1bd3-1f98-3d06-b407-1a7319f0ca71,Canada without Alberta,"reference location, sources:  ecoinvent 3",,Canada without Alberta,61.8,-97.48
-9a0db1a8-1866-3aaa-9f25-881d425e2981,Canada without Alberta or Quebec,"reference location, sources:  ecoinvent 3",,Canada without Alberta or Quebec,63.05,-101.3
-042dd99e-b0ff-3653-814e-445ca0093427,Canada without Quebec,"reference location, sources:  ecoinvent 3.2",,ROC,62.47,-101.92
-888ae6c0-9317-341c-86a4-6bfdf09b72fa,"Canada, Alberta","reference location, sources:  ecoinvent 3",,CA-AB,55.17,-114.5
-391d04b7-aa3e-3b93-9d1f-4d14740ef5f7,"Canada, British Columbia","reference location, sources:  ecoinvent 3",,CA-BC,54.74,-124.76
-e2494db3-71b1-310e-bc75-5ff220d01c47,"Canada, Manitoba","reference location, sources:  ecoinvent 3",,CA-MB,54.92,-97.43
-aa44e6fb-24ea-30f5-9463-91346594e4e8,"Canada, New Brunswick","reference location, sources:  ecoinvent 3",,CA-NB,46.61,-66.37
-2d3a62fe-4d77-3861-9a5d-b0ba1452a7bc,"Canada, Newfoundland and Labrador","reference location, sources:  ecoinvent 3",,CA-NF,52.89,-60.52
-bef33c35-d56a-3154-a9e2-b20a11d7580f,"Canada, Northwest Territories","reference location, sources:  ecoinvent 3",,CA-NT,66.36,-119.0
-c4f314d4-d365-310d-89a0-42946be99544,"Canada, Nova Scotia","reference location, sources:  ecoinvent 3",,CA-NS,45.15,-63.32
-c290d478-7431-3b6d-8372-325203b55c32,"Canada, Nunavut","reference location, sources:  ecoinvent 3",,CA-NU,71.03,-88.84
-5bd185b8-bc04-31d4-8307-5955dc838694,"Canada, Ontario","reference location, sources:  ecoinvent 3",,CA-ON,50.43,-86.06
-24213e9e-14b7-3f9c-be7d-189643518a9d,"Canada, Prince Edward Island","reference location, sources:  ecoinvent 3",,CA-PE,46.39,-63.25
-11c42ab9-2538-3eb1-b665-6076cee71221,"Canada, Yukon","reference location, sources:  ecoinvent 3",,CA-YK,63.63,-135.49
-e7d76f14-42a7-3fc0-bec2-21a3f18683d1,Canary Islands,"reference location, sources:  ecoinvent 3",,Canary Islands,28.33,-15.67
-de3ec0aa-2234-3a1e-bee2-75bbc715c6c9,Cape Verde,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CV,15.07,-23.63
-288ea1e1-79de-3bc8-8a29-958f9857d9d1,Caribbean,"reference location, sources:  ecoinvent 3.2",,UN-CARIBBEAN,20.15,-74.91
-9e854e58-6592-3fe3-961f-e89d56220808,Cayman Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KY,19.31,-81.19
-4e29342d-9904-364e-9e25-fd3b92558e2f,Central African Republic,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CF,6.57,20.48
-41f3dc5d-9734-339d-86ad-47fe2970dfe0,Central America,"reference location, sources:  ecoinvent 3",,UN-CAMERICA,21.8,-99.25
-f60425bb-5d9d-361c-8365-b042007676c0,Central Asia,"reference location, sources:  ecoinvent 3",,Central Asia,45.91,66.48
-35c302ef-c91c-31e9-a4e6-490bbe01a06f,Central European Power Association,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,CENTREL,50.67,18.82
-8b6ba8a9-5220-3f57-8627-6e64a0f1cb40,Central and Eastern Europe,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,EEU,0.0,0.0
-f114427f-29d0-3a63-9781-f1cc950e138e,Centrally Planned Asia and China,"reference location, sources:  ILCD, GaBi",,CPA,0.0,0.0
-626726e6-0bd1-315f-b671-9a308a25b798,Chad,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TD,15.36,18.66
-161747ec-4dc9-355f-9760-195593742232,Chile,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CL,-23.38,-69.43
-7efdfc94-655a-35dc-aa3e-c85e9bb703fa,China,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CN,33.42,106.51
-4c4a60a5-a0d5-369e-ad35-c23714845ace,China Southern Power Grid,"reference location, sources:  ecoinvent 3.2",,CSG,24.56,106.46
-b89fbb5e-5b12-3fbf-84e0-dde2a1af83e7,"China, Anhui (安徽)","reference location, sources:  ecoinvent 3.2",,CN-AH,31.82,117.22
-0c3eee87-5877-3e08-bafd-45af750ca0b8,"China, Beijing (北京)","reference location, sources:  ecoinvent 3.2",,CN-BJ,40.17,116.4
-560cccf0-0b87-306f-bffd-5836e1175a7a,"China, Chongqing (重庆)","reference location, sources:  ecoinvent 3.2",,CN-CQ,30.05,107.85
-f15daa22-c911-3f89-ba04-2f020804afd5,"China, Fujian (福建)","reference location, sources:  ecoinvent 3.2",,CN-FJ,26.07,117.97
-10a33d7b-6e2e-3aa5-8dee-a126f06ae6c1,"China, Gansu (甘肃)","reference location, sources:  ecoinvent 3.2",,CN-GS,37.82,100.92
-e0da2e3f-1c41-368e-b7f1-d1aa54166975,"China, Guangdong (广东)","reference location, sources:  ecoinvent 3.2",,CN-GD,23.35,113.42
-e66b9cb6-fca6-3058-b3fc-ab1eea7e2162,"China, Guangxi (广西壮族自治区)","reference location, sources:  ecoinvent 3.2",,CN-GX,23.83,108.77
-a0e80568-b717-32ee-ac16-0fb0030b51cd,"China, Guizhou (贵州)","reference location, sources:  ecoinvent 3.2",,CN-GZ,26.81,106.87
-c7439785-e07d-3db1-a531-12b8a73fb9c2,"China, Hainan (海南)","reference location, sources:  ecoinvent 3.2",,CN-HA,19.19,109.74
-8f697344-3337-3a4d-a98b-fb261935fd20,"China, Hebei (河北)","reference location, sources:  ecoinvent 3.2",,CN-HB,39.55,116.12
-e40e7f95-3d17-3bfe-bd65-a885f2088578,"China, Heilongjiang (黑龙江省)","reference location, sources:  ecoinvent 3.2",,CN-HL,47.87,127.74
-37c4a9b5-5f7d-3238-bb72-4623cde79d2a,"China, Henan (河南)","reference location, sources:  ecoinvent 3.2",,CN-HE,33.88,113.6
-60418cbc-6847-3b06-a830-253aa9bd9dba,"China, Hubei (湖北)","reference location, sources:  ecoinvent 3.2",,CN-HU,30.97,112.26
-7bbc9d94-7ed7-3d7a-9953-f020aa8fa299,"China, Hunan (湖南)","reference location, sources:  ecoinvent 3.2",,CN-HN,27.61,111.69
-94f8eaf5-2a69-3408-a868-564ba00a53e9,"China, Inner Mongol (内蒙古自治区)","reference location, sources:  ecoinvent 3.2",,CN-NM,44.08,113.9
-1e9be3c3-b260-37d5-8199-be20ff6cc65f,"China, Jiangsu (江苏)","reference location, sources:  ecoinvent 3.2",,CN-JS,32.97,119.44
-8f93bdbf-02dd-37f2-9c94-15b7adb0520c,"China, Jiangxi (江西)","reference location, sources:  ecoinvent 3.2",,CN-JX,27.61,115.71
-5cb7fbc5-6a92-345e-9b8c-205b7d56e247,"China, Jilin (吉林)","reference location, sources:  ecoinvent 3.2",,CN-JL,43.67,126.17
-b6c0a73a-ad7d-352e-a96f-0e22769d89d5,"China, Liaoning (辽宁)","reference location, sources:  ecoinvent 3.2",,CN-LN,41.29,122.61
-fc88ecd5-d3d6-3669-a708-4b9a86e8907d,"China, Ningxia (宁夏回族自治区)","reference location, sources:  ecoinvent 3.2",,CN-NX,37.26,106.16
-8091cd9d-b8ec-3623-a5a2-5b61ea85eb98,"China, Qinghai (青海)","reference location, sources:  ecoinvent 3.2",,CN-QH,35.74,96.0
-442e473c-81d4-34e6-a31e-a13d33c939af,"China, Shaanxi (陕西)","reference location, sources:  ecoinvent 3.2",,CN-SA,35.18,108.86
-21f95e96-39a6-3597-9376-f920757c6fb3,"China, Shandong (山东)","reference location, sources:  ecoinvent 3.2",,CN-SD,36.35,118.15
-26f19341-0269-3662-9c33-6561ad91237f,"China, Shanghai (上海)","reference location, sources:  ecoinvent 3.2",,CN-SH,31.18,121.44
-61ca6a75-802d-39f2-b7b3-09767d6389e0,"China, Shanxi (山西)","reference location, sources:  ecoinvent 3.2",,CN-SX,37.57,112.28
-3ea7c4c6-7057-3b39-96e1-a3251dda63b2,"China, Sichuan (四川)","reference location, sources:  ecoinvent 3.2",,CN-SC,30.61,102.7
-267b1b52-9830-3ddd-bce9-0be0b80a70ec,"China, Tianjin (天津)","reference location, sources:  ecoinvent 3.2",,CN-TJ,39.29,117.32
-524dc282-e858-3e44-b59c-05a258bde0bd,"China, Xinjiang (新疆维吾尔自治区)","reference location, sources:  ecoinvent 3.2",,CN-XJ,41.09,85.18
-7b09132e-4f69-3321-b69f-fbaafccb926a,"China, Xizang (西藏自治区)","reference location, sources:  ecoinvent 3.2",,CN-XZ,31.69,88.1
-9825d889-e0ea-346a-8a60-09d9de7ad000,"China, Yunnan (云南)","reference location, sources:  ecoinvent 3.2",,CN-YN,24.97,101.47
-e22dbdd9-06f5-3598-accc-59c8ff842535,"China, Zhejiang (浙江)","reference location, sources:  ecoinvent 3.2",,CN-ZJ,29.17,120.07
-0bdff809-5c8b-31b3-8775-bf35547a1317,Christmas Island,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CX,-10.44,105.7
-8c37ce4b-665f-30ac-abb4-0fd2a3c43b04,Churchill Falls Generating Station,"reference location, sources:  ecoinvent 3",,Churchill Falls,53.52,-63.99
-8f775bae-e910-3a54-8541-f4a49f87b2f2,Clipperton Island,"reference location, sources:  ecoinvent 3.2",,Clipperton Island,10.29,-109.22
-e0323a90-39ad-3297-8bf5-b49550572c7c,Cocos (Keeling) Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CC,-12.17,96.83
-ab6c0400-6660-3ef2-919d-512b21dce9ab,Colombia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CO,3.9,-73.07
-f9180cb9-286c-39c4-b3a6-c793798b9ddf,Commonwealth of Independent States,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,CIS,45.81,59.08
-9b05de73-d43f-3c4e-8111-0c6bcc5312bc,Comoros,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KM,-11.75,43.33
-6e9cf3ee-f65d-3697-b96c-f33f27eb0f57,Congo,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CG,-0.05,15.98
-6865aeb3-a9ed-38f9-a79e-c454b259e5d0,"Congo, the Democratic Republic of the","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CD,-2.87,23.65
-d5a5b3dd-1ccb-30d3-8360-f0c068fd43fc,Cook Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CK,-21.21,-159.78
-6bb17796-0cff-3545-9414-6bd0821b4560,Coral Sea Islands,"reference location, sources:  ecoinvent 3.2",,Coral Sea Islands,-19.1,151.48
-324d8a1d-3f81-3730-9509-9a48cee0c5b6,Costa Rica,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CR,9.97,-83.94
-adab7b70-1f23-3b82-814c-8506d3dc784e,Croatia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HR,45.72,16.69
-a4dbfd6a-ef3b-3045-be61-aa0146debdf8,Cuba,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CU,21.29,-77.78
-0707ba09-2e91-360b-b05c-326e6a353593,Curaçao,"reference location, sources: ISO 3166-1, ecoinvent 3",,CW,12.19,-68.97
-471c1f3f-c1dd-3bb8-8d03-41b03e4be59e,Cyprus,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CY,35.04,33.21
-b40feb9f-0afa-3eab-9c03-5085ecbbb908,Cyprus No Mans Area,"reference location, sources:  ecoinvent 3.2",,Cyprus No Mans Area,35.1,33.25
-9c049173-fad5-34f8-9c68-231237df85b8,Czech Republic,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CZ,49.74,15.33
-35ea51ba-f1fe-3f01-82ad-5f950855dde0,Côte d'Ivoire,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CI,7.63,-5.55
-0ecbf942-6bcf-3d9a-886d-ed5fc8c4eca8,Denmark,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DK,56.05,9.26
-2a552811-5dc6-3462-a113-dda562233bd7,Dhekelia Sovereign Base Area,"reference location, sources:  ecoinvent 3.2",,Dhekelia Base,35.01,33.79
-64ca6097-2a6e-3926-91c4-b9d31080c687,Djibouti,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DJ,11.9,42.51
-608e7dc1-16de-3157-b060-12b4f0be82ac,Dominica,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DM,15.47,-61.35
-d4579b26-88d6-3523-9f40-2f6b4b43bcbf,Dominican Republic,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DO,19.01,-70.72
-c1717bc2-161f-3b18-90d6-80e24878d689,EU 15,"reference location, sources:  ILCD, GaBi",,EU-15,50.0,4.66
-80e68c50-5cf3-3f11-b809-f8cfbd9a4b17,EU 25 plus candidate countries 2005,"reference location, sources:  ILCD, GaBi",,EU-25&CC,49.0,14.51
-d5ef8373-2ea8-3c9b-9fb5-4f8cb68a9714,EU 25 plus candidate countries 2005 plus associated countries 2005,"reference location, sources:  ILCD, GaBi",,EU-25&CC&AC,0.0,0.0
-322eb489-99c8-380b-8870-87c8d2e958a2,EU 27 plus candidate countries 2007,"reference location, sources: ILCD",,EU-27&CC,0.0,0.0
-aef4c4e7-71b3-3811-876f-5a31fbf8eb0e,EU 27 plus candidate countries 2007 plus associated countries 2007,"reference location, sources: ILCD",,EU-27&CC&AC,0.0,0.0
-9813077a-1292-3b9e-9da5-bd55fa33ecb6,EU associated countries 2005,"reference location, sources:  ILCD, GaBi",,EU-AC,55.33,3.72
-b3c26978-fa5b-3e96-998d-3d5eb0cce441,EU associated countries 2007,"reference location, sources: ILCD",,EU-AC2007,0.0,0.0
-1a88a0a3-7c7f-3bac-96c8-988fe871a18d,EU candidate countries 2005,"reference location, sources:  ILCD, GaBi",,EC-CC,46.39,20.38
-0273c379-31a2-34e3-9d4a-351b4c0f4ef2,EU candidate countries 2007,"reference location, sources: ILCD",,EC-CC2007,0.0,0.0
-1981f919-7ad2-31d5-8748-b520285f6323,EU new member countries 2004,"reference location, sources:  ILCD, GaBi",,EU-NMC,48.7,20.95
-70262596-fdf2-327d-b787-12fb738a9270,EU-25,"reference location, sources:  ILCD, GaBi",,EU-25,50.52,7.59
-5c7f219e-57db-3579-a019-27fb8995651b,EU-27,"reference location, sources:  ILCD, GaBi",,EU-27,50.17,9.15
-e110324f-3d3c-3394-a6f8-f87e742dcaa4,Eastern Africa,"reference location, sources:  ecoinvent 3",,UN-EAFRICA,-5.5,37.09
-95b09ece-0ccc-3fa4-89f0-ef29d63c6dbe,Eastern Asia,"reference location, sources:  ecoinvent 3",,UN-EASIA,38.21,105.25
-db28a51a-61d7-3b0b-bb5c-a1c0a25db72e,Eastern Europe,"reference location, sources:  ecoinvent 3",,UN-EEUROPE,60.98,92.13
-2f53e6f3-f2ac-3041-a4e0-737e58c45321,Ecuador,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,EC,-1.38,-78.49
-2a6a84e9-e444-31af-bd75-cc19ce28be37,Egypt,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,EG,26.49,29.87
-74354112-1c12-3113-af80-7d1582c74bea,El Salvador,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SV,13.73,-88.86
-679f547e-8973-3198-9562-f49522f5f5ac,Electric Reliability Council of Texas,"reference location, sources: DataSmart",,ERCOT,31.1,-97.64
-b84a1ed8-db3d-3bf3-b8f4-9becdea153b2,Equatorial Guinea,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GQ,1.6,10.48
-818f9c45-cfa3-3eef-b277-ef38bcbe9910,Eritrea,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ER,16.04,38.21
-08a4415e-9d59-3ff9-a003-0b921d42b91e,Estonia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,EE,58.67,25.79
-4de1b7a4-dc53-34a8-8c25-ffb7cdb580ee,Ethiopia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ET,8.62,39.61
-d66c264e-1dbd-33e6-911d-3ffc70908e8e,Europe,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RER,54.75,15.24
-c93762d2-a7a3-335c-81c2-fa0be65506df,Europe with NORDEL (NCPA),"reference location, sources:  ecoinvent 3",,Europe with NORDEL (NCPA),54.06,29.67
-06e2458b-3178-3438-b3f4-84051244c27d,"Europe without Austria, Belgium, France, Germany, Italy, Liechtenstein, Monaco, San Marino, Switzerland, and the Vatican","reference location, sources:  ecoinvent 3.2",,RER w/o AT+BE+CH+DE+FR+IT,56.97,30.73
-817ed804-f0ed-3175-b39d-7576a1c242b1,Europe without Switzerland,"reference location, sources:  ecoinvent 3",,Europe without Switzerland,48.59,6.42
-1e11ad8e-d46d-368b-9ef5-a43e99dec543,"Europe, UN Region","reference location, sources:  ecoinvent 3",,UN-EUROPE,54.75,15.24
-73ecfbb1-f6be-3c1e-b05a-aca2cb5b216d,"Europe, without Russia and Turkey","reference location, sources:  ecoinvent 3.2",,"Europe, without Russia and Turkey",53.26,14.59
-8ebf61e1-cf59-357c-b93d-225d0ccb7181,European Network of Transmission Systems Operators for Electricity,"reference location, sources:  ecoinvent 3",,ENTSO-E,49.75,13.56
-ef1cb6e7-2d14-3b18-8cc2-41037203f60b,Falkland Islands (Malvinas),"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FK,-51.66,-58.69
-eed80702-4939-3808-883f-0031a56e9872,Faroe Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FO,62.05,-6.86
-6fac3ab6-03bb-3fb4-ae42-77786393194c,Fiji,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FJ,-17.81,177.97
-75778bf8-fde7-366d-816b-0089e7b8b793,Finland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FI,64.5,26.27
-d1e780c1-ae55-3086-82ed-b9f568342c46,Florida Reliability Coordinating Council,"reference location, sources:  ecoinvent 3",,FRCC,28.32,-81.89
-190aeb66-f132-3e93-995a-70e36f3431c5,Former Soviet Union,"reference location, sources:  ILCD, GaBi",,FSU,47.5,49.29
-82a9e4d2-6595-387a-b6e4-42391d8c5bba,France,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FR,46.56,2.55
-c4f57fe2-5b64-3193-8cfd-d118f11e9024,"France, including overseas territories","reference location, sources:  ecoinvent 3.2",,"France, including overseas territories",42.18,-2.75
-e5bb2379-7bfe-3314-a3db-43d07dbd6a74,French Guiana,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GF,3.92,-53.24
-7287aa2c-53d0-3440-9a9d-b5614937e36f,French Polynesia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PF,-17.62,-149.46
-114d6a41-5b3d-34db-b92c-a7c0da0c7a55,French Southern Territories,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TF,-49.3,69.11
-32d7508f-e692-30cb-80af-28441ef746d9,Gabon,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GA,-0.59,11.79
-92073d2f-e26e-343c-a222-cc0fb0b7d7a0,Gambia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GM,13.45,-15.38
-0ba64a0d-ea00-3479-96df-b6a66866e1ca,Georgia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GE,42.17,43.51
-5f02f088-9301-3d7b-a1ac-972c11bf3e7d,Germany,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,DE,51.11,9.85
-19b19ffc-30ca-3f1c-9376-cd2982992a59,Ghana,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GH,7.96,-1.2
-28dd376c-5a44-3cc9-ae45-0ee338260c56,Gibraltar,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GI,36.13,-5.34
-56bca136-90bb-3a77-9abb-7ce558af711e,Global,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,GLO,0.0,0.0
-d692bc40-d834-33d2-8d3a-37582f58468c,Greece,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GR,39.66,21.76
-ce1d5a24-80e0-34a2-91c1-c7968cc66c13,Greenland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GL,74.71,-41.39
-a6be8a33-b7c9-37f4-bfb7-6d9c9805c7eb,Grenada,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GD,12.11,-61.67
-5343b21a-d303-3f17-9962-9894deca13db,Guadeloupe,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GP,16.28,-61.44
-d2a460df-08a4-3b7a-958f-635b540d90cb,Guam,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GU,13.38,144.7
-1bfad22f-0925-378f-b10a-37440bfdff43,Guatemala,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GT,15.25,-90.39
-73c18c59-a39b-3838-a081-ec00bb456d43,Guernsey,"reference location, sources: ISO 3166-1, ecoinvent 3",,GG,49.45,-2.57
-5123dd8b-087b-344f-9b8f-8603acd1bad4,Guinea,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GN,10.43,-10.94
-3f071f4f-163d-3855-9f4f-c1544c7f69a6,Guinea-Bissau,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GW,12.12,-14.65
-5e08be98-8691-354c-937b-997b4cb6ad97,Guyana,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GY,4.79,-58.97
-add33b5c-114e-39e1-8996-ebe46366c661,HICC,"reference location, sources:  ecoinvent 3",,HICC,20.25,-156.35
-eb5e48e7-4123-3acc-9276-1302ea4a7d22,Haiti,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HT,19.14,-72.27
-2ab5564b-805d-3065-b4bc-f81060472746,Heard Island and McDonald Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HM,-53.11,73.5
-43b1cc1d-b7be-33d8-99dd-4280f578691a,Holy See (Vatican City State),"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VA,41.9,12.45
-59ca4f8b-bb97-33c2-ab59-db115fcdb664,Honduras,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HN,14.81,-86.86
-ae417185-6a75-37b6-bd51-fc0e1f95902e,Hong Kong,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HK,22.42,114.12
-18bd9197-cb1d-333b-8352-f47535c00320,Hungary,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,HU,47.07,19.13
-60a4d810-df1e-3895-95b4-025bbedca798,"IAI producing Area 4 and 5, South and East Asia, without China","reference location, sources:  ecoinvent 3.2",,"IAI Area 4&5, without China",30.77,76.42
-a2a551a6-458a-3de2-a446-cc76d639a9e9,Iceland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IS,64.76,-18.48
-13b5bfe9-6f3e-3fe4-91c9-f66f4a582adf,India,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IN,21.0,78.5
-14b3773a-9228-3ca1-98e3-3d0017100d23,Indian Ocean Territories,"reference location, sources:  ecoinvent 3.2",,AUS-IOT,-10.69,104.61
-b80bb774-0288-3da1-b201-890375a60c8f,Indonesia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ID,-0.97,114.25
-d74eea48-99a6-3f9f-8bc5-27ef988ea0ff,"Iran, Islamic Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IR,32.56,54.3
-795237fd-9d10-3e63-8d19-b0db0f2fba2f,Iraq,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IQ,33.04,43.77
-25400724-d737-3b0b-a9c9-369d9af3dd21,Ireland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IE,53.17,-8.15
-73bebce3-95b6-31ef-adcf-6842fbdb4d76,Isle of Man,"reference location, sources: ISO 3166-1, ecoinvent 3",,IM,54.22,-4.52
-4605f628-f91d-321e-8b5f-9433f46e29eb,Israel,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IL,31.02,34.85
-0d149b90-e739-3297-b01c-90191ae775f0,Italy,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,IT,42.7,12.8
-3da770cc-56ed-3407-b6aa-f10ad4e72b4d,Jamaica,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,JM,18.15,-77.32
-55add3d8-45bf-3d87-a9b0-949b0da49c0a,Japan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,JP,36.49,139.06
-79563e90-630a-3352-9dff-01b6638b0886,Jersey,"reference location, sources: ISO 3166-1, ecoinvent 3",,JE,49.21,-2.12
-674f3384-1e23-39ff-9d24-c85dc3b999de,Jordan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,JO,30.7,36.31
-9008f9e2-758f-38fe-920b-1765e72734d5,Kazakhstan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KZ,48.16,67.3
-25bc6654-798e-3508-ba0b-6343212a74fe,Kenya,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KE,0.53,37.85
-988287f7-a1eb-366f-bc4e-19bdbdeec7c3,Kiribati,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KI,-1.5,175.03
-26b568e4-192a-364d-9b3e-acdbd632bc2e,"Korea, Democratic People's Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KP,39.77,126.45
-dcf0d7d2-cd12-3bf4-a580-d43f29785dd3,"Korea, Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KR,36.5,128.1
-a2d8fced-03cb-3e20-af8e-1226935c9c92,Kosovo,"reference location, sources:  ecoinvent 3.2",,XK,42.57,20.87
-048685d9-6262-3854-82a1-d5bb4a14bc3b,Kuwait,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KW,29.47,47.37
-ebe86682-666f-3ab3-9a08-43ed3097e4b3,Kyrgyzstan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KG,41.46,74.55
-c9089f3c-9ada-3018-af6f-fb1ee8d6501c,Lao People's Democratic Republic,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LA,19.9,102.47
-84502834-6281-3742-9577-a349ea768503,Latin America and the Caribbean,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RLA,-10.11,-65.62
-85d1a9c4-88d7-317e-a862-91a755e5d43c,Latvia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LV,56.85,25.64
-26403ec6-d537-3a31-b63e-294b44831734,Lebanon,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LB,33.92,35.88
-44ba5ca6-5651-34f3-af19-27576dd35436,Lesotho,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LS,-29.58,28.24
-58791f32-2c1b-3c3d-a614-1788d3b8666f,Liberia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LR,6.68,-9.65
-e728b477-51c6-3559-82cb-60f97d1e4553,Libya,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LY,27.04,18.02
-d70c1e5d-44de-3a91-90eb-91ecff563578,Liechtenstein,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LI,47.15,9.55
-d91af695-8918-3f87-96a0-57c1cdf5b225,Lithuania,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LT,55.33,23.89
-3e7e122b-f08f-3843-ac96-1ba491089dc9,Luxembourg,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LU,49.77,6.08
-27c9d518-7cd2-33f8-9160-ec1ed2b5ac89,Macao,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MO,22.2,113.54
-07d93568-0b65-31b2-a42f-e4baea021389,"Macedonia, The Former Yugoslav Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MK,41.59,21.69
-b351bb9b-0af6-34fc-a787-49675c53ad67,Madagascar,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MG,-19.37,46.7
-38fed710-7cee-3580-98ca-06304c1beb90,Malawi,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MW,-13.4,33.8
-6864f389-d987-3436-bc87-78ff071d1b6c,Malaysia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MY,4.2,102.19
-94d03594-5b3d-3218-a669-c4d3f6daa104,Maldives,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MV,3.54,72.92
-9830e1f8-1f62-3b33-906a-cc186b93374e,Mali,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ML,17.35,-3.52
-710998fd-1b7c-3235-9702-65650770a4b1,Malta,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MT,35.89,14.44
-ed8f5b7e-7439-3143-b43a-93dc753618ae,Marshall Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MH,7.59,168.96
-1d8a4975-693e-31eb-9ca5-4878098d608f,Martinique,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MQ,14.65,-61.02
-d9394066-970e-34ae-a52f-d0347e58c03e,Mauritania,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MR,20.26,-10.33
-89aa4b19-6b48-38a1-ba65-49bb1eaebd80,Mauritius,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MU,-20.25,57.58
-fa0ed5b5-c600-345b-9d9a-299952b99651,Mayotte,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,YT,-12.77,45.15
-9c7e385f-c425-3258-a571-a94454d24b2b,Melanesia,"reference location, sources:  ecoinvent 3",,UN-MELANESIA,-7.79,147.87
-3d26b0b1-7065-32cf-a9c0-6c010184c684,Mexico,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MX,23.95,-102.53
-11a4769f-1f94-3ef6-9be6-a120cd4e3e67,Micronesia,"reference location, sources:  ecoinvent 3",,UN-MICRONESIA,7.54,94.38
-0ab34ca9-7d99-3659-9bf8-9817789cb5de,"Micronesia, Federated States of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,FM,6.88,158.23
-e71864bf-656a-3133-8489-a428120c0ada,Middle Africa,"reference location, sources:  ecoinvent 3",,UN-MAFRICA,0.63,19.47
-4b24ca1d-6a54-335b-811e-38a32aaa0967,Middle East,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RME,28.54,48.66
-483bbc62-bf06-31a1-9aca-efa0a24e2f1e,Middle East and North Africa,"reference location, sources:  ILCD, GaBi",,MEA,28.63,34.24
-cda0fd29-18d1-3e20-ac87-1ed79a8d2bb0,Midwest Reliability Organization,"reference location, sources:  ecoinvent 3",,MRO,50.58,-99.64
-8ce8d793-183f-312a-a33c-5c61ec31edb6,Midwest Reliability Organization (USA),"reference location, sources:  ecoinvent 3",,Midwest Reliability Organization (USA),44.82,-96.82
-793914c9-c583-39d8-ad0f-4ed8c521b0c1,"Moldova, Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MD,47.19,28.59
-d6fd0924-e324-3506-a9ae-0295adf59567,Monaco,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MC,43.75,7.41
-41256636-7c67-348b-999d-1b7666f8ccfc,Mongolia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MN,46.05,102.87
-ab86a1e1-ef70-3ff9-b959-067b723c5c24,Montenegro,"reference location, sources: ISO 3166-1, ecoinvent 3",,ME,42.79,19.25
-ee33e909-372d-335d-990f-4fcb2a92d542,Montserrat,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MS,16.73,-62.18
-b74df323-e393-3b56-b635-a2cba7a7afba,Morocco,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MA,32.7,-5.75
-4f3dd0ff-b3e4-3c5f-b4b5-b0d8c1f10bb5,Mozambique,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MZ,-14.42,37.92
-b3cd915d-7580-38bd-99d0-f2428fbb354a,Myanmar,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MM,21.71,96.04
-6ec66e12-4fb9-3c19-8e92-07b0b82f542a,Namibia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NA,-22.13,17.21
-0ab3e5d0-801a-3a3f-b758-bcbd812e8f10,Nauru,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NR,-0.52,166.93
-40590d3d-1a34-3650-81f5-e48b08ef2096,Near East,"reference location, sources:  ILCD, GaBi",,RNE,33.72,39.81
-cf3fc916-339b-32ad-9c14-aca2425ccf53,Nepal,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NP,28.25,83.93
-1a13105b-7e4e-35fb-ae7c-9515ac06aa48,Netherlands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NL,52.07,5.38
-18b049cc-8d85-3578-b929-df716f9f4e68,Netherlands Antilles,"reference location, sources:  ILCD, GaBi",,AN,12.12,-68.87
-1e734284-5e24-3b3b-9b35-54490da1c128,New Caledonia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NC,-21.35,165.44
-5c0f2c74-2dc9-3fce-b75d-086e7412f81f,New South Wales,"reference location, sources:  ecoinvent 3.2",,AUS-NSW,-32.16,147.01
-c97b334f-fd41-3a49-9708-3f1949632bc1,New Zealand,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NZ,-42.63,172.23
-e6c151d4-49e1-3b05-b1ff-b5ad5ec656cf,Nicaragua,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NI,12.84,-85.03
-d4f91763-3649-33c4-bc7a-b917fa990146,Niger,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NE,17.42,9.39
-66e10e9f-f65e-3479-a54d-de3968d3440d,Nigeria,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NG,9.59,8.1
-0288bde0-c2d5-33f2-b576-6f61b826a650,Niue,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NU,-19.05,-169.86
-4205164e-e2e5-30d6-98fb-7657af40aed6,Nordic Countries Power Association,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,NORDEL,63.76,18.88
-78d9238c-1a21-3c8b-be8f-6c26172fb12d,Norfolk Island,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NF,-29.03,167.95
-16096b94-483a-3671-b7a2-16db4118f8df,North American Free Trade Agreement,"reference location, sources:  ecoinvent 3",,NAFTA,53.42,-104.01
-588c9ca2-d66d-3e43-b7b3-65bfd7e971cf,Northeast Power Coordinating Council,"reference location, sources:  ecoinvent 3",,NPCC,51.25,-76.32
-f9d758b6-d15e-3238-aa0e-e0a3b949fc32,Northern Africa,"reference location, sources:  ecoinvent 3",,UN-NAFRICA,23.88,15.96
-b320e7db-c758-3ba6-8839-81eb83c9d7d7,Northern America,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,RNA,58.71,-91.96
-bd6ef2ee-f612-38be-bce0-90c8e64ebaa9,Northern Cyprus,"reference location, sources:  ecoinvent 3.2",,Northern Cyprus,35.27,33.59
-da657f65-6f70-3a48-893f-64cf7be37d09,Northern Europe,"reference location, sources:  ecoinvent 3",,UN-NEUROPE,63.06,13.8
-1f2dfa56-7dcf-3583-bedd-f7aec167fec7,Northern Mariana Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,MP,15.0,145.62
-4382e0b4-8ddb-3600-bf3d-10de8fabfb86,Northern Territory,"reference location, sources:  ecoinvent 3.2",,AUS-NTR,-19.41,133.36
-7fa3b767-c460-354a-abe4-d49030b349c7,Norway,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,NO,61.15,8.74
-61c8d2f5-500d-37c3-a13e-4ed176dcf6d2,Oceania,"reference location, sources:  ecoinvent 3",,UN-OCEANIA,-25.28,136.4
-6aa2b79b-1fc3-384c-b1af-565b51d5e4ad,Oceanic,"reference location, sources:  ILCD, GaBi",,OCE,0.0,0.0
-d58da822-8993-3d8c-8ec4-f40689c2847e,Oman,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,OM,21.65,57.4
-cd0acfe0-85ee-30f8-b439-1fb9b8009bed,Other Pacific Asia,"reference location, sources:  ILCD, GaBi",,PAS,12.39,123.83
-655ae040-aec1-37f7-8d79-0580c5ac37ab,"Pacific OECD (Japan, Australia, New Zealand)","reference location, sources:  ILCD, GaBi",,PAO,-9.99,148.97
-1cd3c693-132f-3c31-b5b5-e5f4c5eed6bd,Pakistan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PK,29.96,69.38
-8fe4c114-5128-3c09-8a65-78e6ddbf5eed,Palau,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PW,7.5,134.57
-8812c36a-a5ae-336c-aa77-bf63211d899a,"Palestinian Territory, Occupied","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PS,32.03,35.27
-e529a9ce-a4a7-38eb-9c58-28b13b22844c,Panama,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PA,8.38,-80.92
-235ec523-92b7-3977-939c-f78b62e708d3,Papua New Guinea,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PG,-5.94,143.45
-dfed5bc1-77b8-3ab3-97c5-84e06566adc6,Paraguay,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PY,-23.23,-58.39
-dd07de85-6139-3a7c-b7f8-fcc1752d45e1,Peru,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PE,-9.32,-75.55
-da984e42-a589-3bbd-ac49-6ef0cbadcee2,Philippines,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PH,11.11,122.46
-ded0804c-f804-36d2-ae37-953dc2dbc505,Pitcairn,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PN,-24.36,-128.31
-28840420-4e3d-3522-a930-8317344a285d,Poland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PL,52.12,19.4
-b9b1f592-541c-3b02-bd41-1f6ea05a6ea5,Polynesia,"reference location, sources:  ecoinvent 3",,UN-POLYNESIA,-15.29,-158.9
-fc9fdf08-4e29-3f26-a270-390dc49061a2,Portugal,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PT,40.3,-8.05
-64e1e1cb-e1ca-3e88-af3a-838a3e7b57d6,Puerto Rico,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PR,18.22,-66.46
-8264ee52-f589-34c0-991a-a94f87aa1aeb,Qatar,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,QA,25.31,51.19
-ceaa2d09-0b6e-398c-98b3-41c15d7db178,Queensland,"reference location, sources:  ecoinvent 3.2",,AUS-QNS,-22.57,144.55
-1e2bf244-82a6-36c2-9374-13eae0aeac38,Québec,"reference location, sources:  ecoinvent 3",,Québec,53.39,-71.75
-6c68ef81-a341-3ab2-bc21-e280c511bd86,"Québec, HQ distribution network","reference location, sources:  ecoinvent 3",,"Québec, HQ distribution network",50.49,-72.38
-1560a2df-f599-3750-9974-8cbda44b4c51,ReliabilityFirst Corporation,"reference location, sources:  ecoinvent 3",,RFC,40.81,-82.23
-f1965a85-7bc2-35d2-afe2-2023aa5ab50d,Rest-of-World,"reference location, sources:  ecoinvent 3",,RoW,0.0,0.0
-3605c251-087b-3821-ac9b-ca890e07ad9c,Romania,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,RO,45.84,24.96
-7d199e42-c733-3c12-87e1-ce5672f33ae6,Russia (Asia),"reference location, sources:  ecoinvent 3.2",,Russia (Asia),62.73,110.63
-84c26536-0d12-33e3-8ed0-e7fa435f9a45,Russia (Europe),"reference location, sources:  ecoinvent 3.2",,Russia (Europe),59.24,45.62
-89484b14-b36a-3d53-a942-6a3d944d2983,Russian Federation,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,RU,61.84,97.03
-038c0dc8-a958-3fea-97af-047244fb6960,Rwanda,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,RW,-1.99,29.91
-12eccbdd-9b32-3181-b134-1f38907cbbb5,Réunion,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,RE,-21.12,55.53
-44193271-0d3b-309d-b869-820f52c4c6db,SERC Reliability Corporation,"reference location, sources:  ecoinvent 3",,SERC,34.99,-86.47
-fd18772c-bac1-3277-b20d-cccc1b90efb9,Saint Barthélemy,"reference location, sources: ISO 3166-1, ecoinvent 3",,BL,18.04,-63.04
-77cbc257-e663-3286-acf6-191754c0c8e3,"Saint Helena, Ascension and Tristan da Cunha","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SH,-15.95,-5.71
-8c7e6965-b416-3689-a88b-313bbe7450f9,Saint Kitts and Nevis,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,KN,17.34,-62.76
-196accbc-f32b-3a8e-abef-92e1a37d0fc0,Saint Lucia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LC,13.89,-60.96
-ea81aa7d-f47d-34c6-b37b-f98fabf3ff82,Saint Martin (French part),"reference location, sources: ISO 3166-1, ecoinvent 3",,MF,18.09,-63.04
-5109d85d-95fe-3e78-96d9-704e6e5b1279,Saint Pierre and Miquelon,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,PM,47.04,-56.32
-c56e5259-4d4e-3e7f-acb2-b96c4637b486,Saint Vincent and the Grenadines,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VC,13.24,-61.19
-742523da-ef59-3b4b-b184-09f46de05d0c,Samoa,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,WS,-13.65,-172.41
-ed79acb0-cd3d-3f83-a0c5-3c7798335ef0,San Marino,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SM,43.94,12.46
-627fcdb6-cc9a-3e16-9657-ca6cdef0a6bb,Sao Tome and Principe,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ST,0.2,6.62
-6108d9a8-6ab3-3a57-b470-a194c15a1d16,Saskatchewan,"reference location, sources:  ecoinvent 3",,CA-SK,54.41,-105.88
-c12e01f2-a13f-3558-be1e-9e4aedb8242d,Saudi Arabia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SA,24.02,44.58
-d0ea3a63-8908-3b86-a4f9-10b6170de942,Scarborough Reef,"reference location, sources:  ecoinvent 3.2",,Scarborough Reef,15.15,117.75
-afbe94cd-be69-393e-babc-9f1325fc7dff,Senegal,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SN,15.01,-14.88
-3a2d7564-baee-3918-aebc-7b65084aabd1,Serbia,"reference location, sources: ISO 3166-1, ecoinvent 3",,RS,44.03,20.8
-95cc64dd-2825-39df-93ec-4ad683ecf339,Serbia and Montenegro,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,CS,43.86,20.59
-cc9dabdf-852c-3698-ae98-b3d1d8b1c324,Serranilla Bank,"reference location, sources:  ecoinvent 3.2",,Serranilla Bank,15.86,-78.63
-d54185b7-1f61-3c30-a396-ac4bc44d3269,Seychelles,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SC,-4.64,55.47
-5f507fb0-b905-3a32-bb57-967d0a3b3b43,Siachen Glacier,"reference location, sources:  ecoinvent 3.2",,Siachen Glacier,35.39,77.17
-54a2bf8c-09ac-367d-b513-aaa1aa7aa0f3,Sierra Leone,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SL,8.56,-11.79
-5dae4296-88af-3c52-9ad8-7ac394192c6d,Singapore,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SG,1.35,103.8
-2c38b9e4-5cec-3b32-8dde-4e3d5b22c648,Sint Maarten (Dutch part),"reference location, sources: ISO 3166-1, ecoinvent 3",,SX,12.56,-68.33
-41d6ad07-61a5-327a-9e1b-d567041ce9e9,Slovakia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SK,48.7,19.49
-ac5585d9-8646-3255-a99c-359140537783,Slovenia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SI,46.12,14.82
-26148d62-1ef7-3844-918a-f182d63976b6,Solomon Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SB,-9.61,160.1
-b807023f-87e6-3b8a-9a92-f79f546ff9cc,Somalia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SO,9.77,48.31
-4f146d3d-de5e-3896-8bac-17f57c9eaa05,Somaliland,"reference location, sources:  ecoinvent 3.2",,Somaliland,9.73,46.25
-959848ca-10cc-3a60-9a81-8ac11523dc63,South Africa,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ZA,-30.55,23.12
-d34c6aba-144a-3e2d-acb4-0dd5f93ae50e,South America,"reference location, sources:  ecoinvent 3",,UN-SAMERICA,-15.03,-60.73
-1494adfb-98f4-3dc3-83b2-10bead2efff7,South Australia,"reference location, sources:  ecoinvent 3.2",,AUS-SAS,-30.1,135.82
-1d8d5e91-2302-308b-9e88-c3e77fcad378,South Georgia and the South Sandwich Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GS,-54.2,-36.89
-3691308f-2a4c-3f69-83f2-880d32e29c84,South Sudan,"reference location, sources: ISO 3166-1, ecoinvent 3",,SS,7.3,30.25
-e832ff92-78c2-3ab2-8f7d-d0ca126994bf,South-Eastern Asia,"reference location, sources:  ecoinvent 3",,UN-SEASIA,7.93,109.93
-326dde39-0b64-3523-b09f-aa0f427066d8,Southern Africa,"reference location, sources:  ecoinvent 3",,UN-SASIA,-25.49,22.53
-a8a64cef-262a-34de-8872-b68b63ab7cd8,Southern Asia,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,SAS,7.93,109.93
-fe8f0f22-0c96-348b-86c2-b27e42d27f04,Southern Europe,"reference location, sources:  ecoinvent 3",,UN-SEUROPE,41.48,7.31
-5566919c-eb38-3560-957c-4fddbf8314c7,Southwest Power Pool,"reference location, sources:  ecoinvent 3",,SPP,36.18,-97.9
-12470fe4-06d4-3017-996e-ab37dd65fc14,Spain,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ES,40.22,-3.64
-e914aa2b-6272-3660-9305-a03124b4d9a8,Spratly Islands,"reference location, sources:  ecoinvent 3.2",,Spratly Islands,10.54,114.92
-d0fa06cd-9333-3c8c-ae35-7ffe5cd1c4e9,Sri Lanka,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,LK,7.61,80.7
-6515e168-6762-351f-b146-9deb97414906,State Grid Corporation of China,"reference location, sources:  ecoinvent 3.2",,SGCC,37.81,103.55
-748ced3d-d3ad-3822-bb8f-2e73f28ef722,Sub-Sahara Africa,"reference location, sources:  ILCD, GaBi",,AFR,-1.23,18.32
-6226f7cb-e59e-39a9-8b5c-ef6f94f966fd,Sudan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SD,15.98,29.93
-e22428cc-f96c-3a96-b4a9-39c209ad1000,Suriname,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SR,4.12,-55.91
-b5bf27b2-555d-344e-bdf2-230080db5a1d,Svalbard and Jan Mayen,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SJ,78.82,18.37
-7dabf5c1-98b0-3ab2-aaa4-2bb03a113e55,Swaziland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SZ,-26.56,31.49
-efad7abb-323e-3d40-9628-4c8a6da076a1,Sweden,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SE,62.01,15.27
-d88fc6ed-f21e-3464-935f-f76288b84103,Switzerland,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,CH,46.86,7.9
-1548af1c-94ad-3558-8324-df8f08baf227,Syrian Arab Republic,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,SY,35.01,38.5
-255a5cac-7685-3722-b4d0-2f04c37be771,"Taiwan, Province of China","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TW,23.75,120.94
-456c2e75-fe0f-3a57-bd1c-fd87117e0963,Tajikistan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TJ,38.66,69.42
-73bb4387-b307-3739-aacb-9cd62ac4049c,"Tanzania, United Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TZ,-6.27,34.82
-5bb22373-e69e-31fe-b00e-0a38a7129c8c,Tasmania,"reference location, sources:  ecoinvent 3.2",,AUS-TSM,-41.93,146.59
-7e764aa6-b752-3530-855f-0373606d1886,Texas Regional Entity,"reference location, sources:  ecoinvent 3",,TRE,30.91,-99.21
-1fdc0f89-3412-3e55-b0d2-811821b84d3b,Thailand,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TH,15.7,100.84
-313a21d5-badc-3f56-b223-8ebf8c7690f6,Timor-Leste,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TL,-8.82,125.87
-1f0eb098-5870-335e-a2fa-2f68a223b173,Togo,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TG,8.79,1.08
-b6717b91-c759-3cc0-bf30-aa9a784e6390,Tokelau,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TK,-9.19,-171.85
-01b6e203-44b6-3835-85ed-1ddedf20d531,Tonga,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TO,-21.2,-175.18
-accc9105-df53-3311-9407-fd5b41255e23,Trinidad and Tobago,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TT,10.46,-61.25
-aafb96b2-fa88-36be-b07c-4496867bad56,Tunisia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TN,35.38,9.59
-e7d707a2-6e7f-3b6f-b52c-489c60e429b1,Turkey,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TR,39.06,35.17
-6a962563-e235-3178-9e66-3e356ac8d9e4,Turkmenistan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TM,39.12,59.38
-5c4fefda-27cf-384c-b999-be13e6b8608a,Turks and Caicos Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TC,21.9,-71.95
-c9a1fdac-6e08-3dd8-9e71-73244f34d7b3,Tuvalu,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,TV,-8.51,179.21
-e743b51e-41f8-3369-9418-34177c8f34e7,UCTE without France,"reference location, sources:  ecoinvent 3",,UCTE without France,46.03,12.52
-cdba052d-e53c-3173-b857-3d555fad2c16,UCTE without Germany,"reference location, sources:  ecoinvent 3",,UCTE without Germany,45.45,10.92
-8dc6a685-44c9-3a1c-b937-78a6de2d9830,UCTE without Germany and France,"reference location, sources:  ecoinvent 3",,UCTE without Germany and France,45.18,12.88
-aae773f6-9106-3fd9-95d0-c38764e6dccd,US Naval Base Guantanamo Bay,"reference location, sources:  ecoinvent 3.2",,Guantanamo Bay,19.92,-75.15
-2a0617ac-cf8b-3862-9c43-e2ffeb5b8d5b,Uganda,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,UG,1.28,32.38
-5269f4d7-5f5b-375f-8f94-bab2100a5531,Ukraine,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,UA,49.01,31.38
-b633c174-f67b-3819-a2a4-ef89f2d5b8cb,Union for the Co-ordination of Transmission of Electricity,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,UCTE,46.09,10.8
-b6bb43df-4525-3928-a105-fb5741bddbea,United Arab Emirates,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AE,23.54,54.16
-7885444a-f42e-3b30-8518-c5be17c8850b,United Kingdom,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,GB,53.0,-1.6
-0b3b97fa-6688-3c56-88ee-4ae80ec0c3c2,United States,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,US,39.62,-98.6
-0dd00e33-b6fc-37b8-91eb-e3177217d6c0,United States Minor Outlying Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,UM,-0.38,-160.02
-c385c23d-66c3-3558-989c-db5586384532,"United States, Alabama","reference location, sources: USDA, DataSmart",,US-AL,32.79,-86.8
-b423ff37-b678-3ea4-9366-ede7b1a7c0c0,"United States, Alaska","reference location, sources: DataSmart",,US-AK,61.38,-152.26
-b7745632-fc6d-37f8-85f0-f53c48027b96,"United States, Arizona","reference location, sources: USDA, DataSmart",,US-AZ,33.77,-111.38
-b54bf461-c111-318c-9f92-a499f34dc05d,"United States, Arkansas","reference location, sources: USDA, DataSmart",,US-AR,34.95,-92.38
-b775ab58-2693-342d-b496-3265a17b5b32,"United States, California","reference location, sources: USDA, DataSmart",,US-CA,36.17,-119.74
-12fe7ead-4836-3c05-bbd9-768e2f0fdb66,"United States, Colorado","reference location, sources: USDA, DataSmart",,US-CO,39.06,-105.32
-e86115dd-61e0-3652-8b8f-79fc693dcf01,"United States, Connecticut","reference location, sources: DataSmart",,US-CT,41.58,-72.76
-1ae4da05-1c10-36a3-aadc-da3431d1b677,"United States, Delaware","reference location, sources: USDA, DataSmart",,US-DE,39.34,-75.51
-efe104ea-d72b-3371-940f-1bb877257ab3,"United States, District of Columbia","reference location, sources: DataSmart",,US-DC,38.89,-77.02
-445fe89e-beea-3ff9-8975-167f35b53373,"United States, Florida","reference location, sources: USDA, DataSmart",,US-FL,27.83,-81.71
-2b701fc6-ef0e-3b9a-9f4d-631863e904f6,"United States, Georgia","reference location, sources: USDA, DataSmart",,US-GA,32.98,-83.64
-fe2bd352-e70f-3e48-a023-02843b5ac978,"United States, Hawaii","reference location, sources: DataSmart",,US-HI,21.1,-157.53
-1f80437b-a9fb-34e0-a052-26a2a7fd5520,"United States, Idaho","reference location, sources: USDA, DataSmart",,US-ID,44.23,-114.51
-c2521c9e-e466-3960-b789-4046cadadf24,"United States, Illinois","reference location, sources: USDA, DataSmart",,US-IL,40.33,-89.0
-70f8ca91-42c2-3bae-a4e2-dcc1b8033abe,"United States, Indiana","reference location, sources: USDA, DataSmart",,US-IN,39.86,-86.26
-fa384517-d567-36e2-9a5a-dd52df663dcf,"United States, Iowa","reference location, sources: USDA, DataSmart",,US-IA,42.0,-93.21
-d9c55cbc-3e12-3ff1-9370-bdfebddccd5f,"United States, Kansas","reference location, sources: USDA, DataSmart",,US-KS,38.51,-96.8
-e132e45b-712d-3e2c-af19-c1f1b99c3c91,"United States, Kentucky","reference location, sources: USDA, DataSmart",,US-KY,37.66,-84.65
-c384a41a-bbea-3bc9-b333-75287ddb64bb,"United States, Louisiana","reference location, sources: USDA, DataSmart",,US-LA,31.18,-91.87
-4d844119-4127-3a4d-b856-663e8039d21c,"United States, Maine","reference location, sources: DataSmart",,US-ME,44.6,-69.39
-86596f8c-55cb-3a71-976f-6a56e871f29b,"United States, Maryland","reference location, sources: USDA, DataSmart",,US-MD,39.07,-76.79
-85a8277c-cb62-3889-ae66-71d05d9263d3,"United States, Massachusetts","reference location, sources: DataSmart",,US-MA,42.23,-71.53
-bb966cd1-e1ba-33fd-8375-56d66970d7df,"United States, Michigan","reference location, sources: USDA, DataSmart",,US-MI,43.35,-84.56
-7aa1c4da-339b-3230-8838-2de0f6a6581a,"United States, Minnesota","reference location, sources: USDA, DataSmart",,US-MN,45.73,-93.91
-0ee63262-59b9-3da8-8cf7-5f42828ffa7b,"United States, Mississippi","reference location, sources: USDA, DataSmart",,US-MS,32.76,-89.68
-cdc9423a-0890-3494-b717-51263425bcf6,"United States, Missouri","reference location, sources: USDA, DataSmart",,US-MO,38.46,-92.3
-a220b227-87c9-368d-8bfe-5ff357517419,"United States, Montana","reference location, sources: USDA, DataSmart",,US-MT,46.9,-110.32
-669eb22e-cf87-3b59-a553-06880eed6a5a,"United States, Nebraska","reference location, sources: USDA, DataSmart",,US-NE,41.12,-98.28
-f9eab7a5-2fbd-36f4-b88f-438ba1a8da94,"United States, Nevada","reference location, sources: DataSmart",,US-NV,38.41,-117.12
-ca2b1447-f5e7-3554-b244-ee56ce0e92ff,"United States, New Hampshire","reference location, sources: DataSmart",,US-NH,43.41,-71.56
-52c1fc37-d9e9-33a1-aaea-c2bc601b0364,"United States, New Jersey","reference location, sources: DataSmart",,US-NJ,40.31,-74.5
-560e664b-9150-3314-b530-1eaa6af5b067,"United States, New Mexico","reference location, sources: DataSmart",,US-NM,34.83,-106.23
-0efe3dd6-681d-3dd2-8970-52bea5982168,"United States, New York","reference location, sources: USDA, DataSmart",,US-NY,42.14,-74.93
-cf1fe73c-b3b8-3e6a-a362-a24cc00edca8,"United States, North Carolina","reference location, sources: USDA, DataSmart",,US-NC,35.64,-79.84
-7d5a6438-e66c-37d7-b069-9f6cbb9efb22,"United States, North Dakota","reference location, sources: USDA, DataSmart",,US-ND,47.53,-99.79
-8f530ffb-71ad-30e5-8e27-ea335b94166f,"United States, Ohio","reference location, sources: USDA, DataSmart",,US-OH,40.37,-82.77
-9704b0fb-3771-33d7-a07d-a7d6e1a431a2,"United States, Oklahoma","reference location, sources: USDA, DataSmart",,US-OK,35.53,-96.92
-7fb70584-7e67-3d35-9d3a-16a62784d3a3,"United States, Oregon","reference location, sources: USDA, DataSmart",,US-OR,44.56,-122.12
-22b8b398-1b5b-3955-a162-614bb67b5927,"United States, Pennsylvania","reference location, sources: USDA, DataSmart",,US-PA,40.57,-77.26
-869d2f4d-09bf-3b85-b19d-3cd046b07ac5,"United States, Rhode Island","reference location, sources: DataSmart",,US-RI,41.67,-71.51
-58a2cc24-3eaf-3596-988e-742e109b66fd,"United States, South Carolina","reference location, sources: USDA, DataSmart",,US-SC,33.81,-80.9
-112e6937-5e63-32a1-ba68-730cbd933c75,"United States, South Dakota","reference location, sources: USDA, DataSmart",,US-SD,44.28,-99.46
-1be0b149-5590-34c3-bee8-fdb3255c95f4,"United States, Tennessee","reference location, sources: USDA, DataSmart",,US-TN,35.74,-86.74
-f767f1ae-d126-3766-846d-62fa2f6f927f,"United States, Texas","reference location, sources: USDA, DataSmart",,US-TX,31.1,-97.64
-10334e82-fe92-33bf-9d45-2decb730b1c2,"United States, Utah","reference location, sources: DataSmart",,US-UT,40.11,-111.85
-3b7e10ba-fd35-381d-8ff5-8811c0f6bf32,"United States, Vermont","reference location, sources: DataSmart",,US-VT,44.04,-72.7
-4ec8c4f4-fd4d-3a38-80a5-7446f9420f11,"United States, Virginia","reference location, sources: USDA, DataSmart",,US-VA,37.76,-78.2
-9ef574c2-cd1a-3866-b782-5e74b2c6cfcb,"United States, Washington","reference location, sources: USDA, DataSmart",,US-WA,47.39,-121.57
-a8ce62fb-3610-311c-8af0-a8bf4942f5a0,"United States, West Virginia","reference location, sources: DataSmart",,US-WV,38.46,-80.96
-38af12ff-e146-3293-a429-6ddf9c28b806,"United States, Wisconsin","reference location, sources: USDA, DataSmart",,US-WI,44.25,-89.63
-373367f9-6d69-3917-ac7a-b9b523b4f30f,"United States, Wyoming","reference location, sources: DataSmart",,US-WY,42.74,-107.2
-1b23f8a4-c97c-355f-b57e-c2aae921f03d,Uruguay,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,UY,-32.8,-56.01
-8b3274b7-55aa-3339-82f5-7fb557e25923,Uzbekistan,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,UZ,41.75,63.17
-0730b75e-96c0-353b-9b19-6be7ff4fa194,Vanuatu,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VU,-15.37,166.89
-eabb18f0-a40c-3b35-9237-0c9e1bc1d61e,"Venezuela, Bolivarian Republic of","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VE,7.12,-66.16
-b04ebbb9-1260-3d5b-a16f-5f2a16c4886e,Victoria,"reference location, sources:  ecoinvent 3.2",,AUS-VCT,-36.85,144.3
-5e9c52c6-d618-381e-bd9d-62a294c4979c,Viet Nam,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VN,21.49,105.31
-1815235d-384d-3912-9466-8c73298f1e52,"Virgin Islands, British","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VG,18.5,-64.48
-35b36b28-916d-38b3-8abd-df832e286126,"Virgin Islands, U.S.","reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,VI,17.96,-64.78
-c1b291cb-8522-336e-8217-31b509c9fcdd,Wallis and Futuna,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,WF,-13.78,-177.14
-fb033b5d-d7d0-37f5-a147-c0bfed75d56c,Western Africa,"reference location, sources:  ecoinvent 3",,UN-WAFRICA,14.74,-1.17
-02cb9a5a-488d-3ea0-84d9-3ae7b315e386,Western Asia,"reference location, sources:  ecoinvent 3",,UN-WASIA,28.46,43.36
-2ccce7fd-714d-3ce6-8a5d-909f98c8819f,Western Australia,"reference location, sources:  ecoinvent 3.2",,AUS-WAS,-25.46,122.17
-f62a6cfc-7bf3-3556-a8b3-a168accf9875,Western Electricity Coordinating Council,"reference location, sources:  ecoinvent 3",,WECC,46.6,-116.2
-27ec30d1-c271-32b7-8cdf-d39530307275,Western Europe,"reference location, sources:  ecoinvent 3, ILCD, GaBi",,WEU,48.53,6.48
-28c494da-87ff-3996-9927-ac34ba30adbe,Western Sahara,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,EH,24.55,-13.7
-00c66f1a-036b-38f9-8b70-9cb8d925d3d9,Yemen,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,YE,15.8,48.35
-d9c29677-6530-3ff5-92a5-ab979ed1f7a0,Zambia,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ZM,-14.61,26.32
-a1555463-c361-3703-aa27-4a8b44e29192,Zimbabwe,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,ZW,-19.0,29.87
-9cea1e24-73aa-3499-95fa-34faac95b3e7,Åland Islands,"reference location, sources: ISO 3166-1, ecoinvent 3, ILCD, GaBi",,AX,60.19,19.95
+f0357a3f-154b-32ff-a2bf-f55055457068,Afghanistan,,Country,AF,33.83,66.0
+0d0ac1d0-76ad-307d-8b0e-05f06c746da9,Africa,,Global,RAF,6.42,18.28
+9ebe579b-1c4d-361f-97a7-4d7f59fcb7a6,Akrotiri Sovereign Base Area,,Miscellaneous,Akrotiri Sovereign Base Area,34.63,32.93
+97282b27-8e5d-3186-af8e-57204e4820e5,Albania,,Country,AL,41.14,20.05
+0de7b6a6-1a70-388b-a6e6-eeb3113531a3,Algeria,,Country,DZ,28.14,2.65
+f970e276-7d0c-3e75-876e-a857f92e319b,American Samoa,,Country,AS,-14.25,-170.39
+6b356dcf-86c7-3e74-826f-3ae5725687d3,Americas,,Global,UN-AMERICAS,35.46,-83.09
+523af537-946b-39c4-b836-9ed39ba78605,Andorra,,Country,AD,42.54,1.56
+adac5e63-f80f-3629-a957-3527b25891d3,Angola,,Country,AO,-12.29,17.53
+4921c0e2-d1f6-305a-be1f-9ec2e2041909,Anguilla,,Country,AI,18.22,-63.05
+b2b04af9-f8f3-3b06-a29e-03ac8d3c24ca,Antarctica,,Country,AQ,-80.51,19.97
+4e42f7dd-43ec-3fe1-84de-58610557c5ba,Antigua and Barbuda,,Country,AG,17.28,-61.79
+c582dec9-43ff-3b74-baa0-691df291cea6,Argentina,,Country,AR,-35.37,-65.17
+c04cd38a-eb30-33ad-9f8a-b4e64a0ded7b,Armenia,,Country,AM,40.28,44.93
+b787d22d-9cb0-3342-a58b-f546039117bc,Aruba,,Country,AW,12.51,-69.97
+1c280670-4821-3d48-b168-efc6d6685406,Asia,,Global,RAS,45.29,95.75
+9331c8d7-3b48-3a8f-a4a8-2ea976840ba9,Asia without China,,Cutout,Asia without China,47.17,94.01
+e39deabc-78c0-37a0-a5dd-30a225aa9eec,"Asia, UN Region",,Global,UN-ASIA,32.21,84.6
+8bcc25c9-6aa5-371f-ba76-309077753e67,Australia,,Country,AU,-25.73,134.49
+05b093bc-7b17-3c30-a09d-1c41f13e009a,Australia and New Zealand,,Global,UN-AUSTRALIANZ,-26.37,135.97
+bc388e13-830e-35bd-8be3-d90b027ac5ad,"Australia, Ashmore and Cartier Islands",,Miscellaneous,AU-AS,-12.43,123.58
+3e91fecc-17db-3393-ad8f-0e2c0131053d,"Australia, Australian Capital Territory",,Subdivisions,AU-ACT,-35.49,149.0
+161ff7b5-7ecf-4021-8fff-5def0bf2b27e,"Australia, including overseas territories",,Miscellaneous,"Australia, including overseas territories",-25.73,134.48
+5c0f2c74-2dc9-3fce-b75d-086e7412f81f,"Australia, New South Wales",,Subdivisions,AU-NSW,-32.16,147.01
+4382e0b4-8ddb-3600-bf3d-10de8fabfb86,"Australia, Northern Territory",,Subdivisions,AU-NT,-19.41,133.36
+ceaa2d09-0b6e-398c-98b3-41c15d7db178,"Australia, Queensland",,Subdivisions,AU-QLD,-22.57,144.55
+1494adfb-98f4-3dc3-83b2-10bead2efff7,"Australia, South Australia",,Subdivisions,AU-SA,-30.1,135.82
+5bb22373-e69e-31fe-b00e-0a38a7129c8c,"Australia, Tasmania",,Subdivisions,AU-TAS,-41.96,146.62
+b04ebbb9-1260-3d5b-a16f-5f2a16c4886e,"Australia, Victoria",,Subdivisions,AU-VIC,-36.85,144.3
+2ccce7fd-714d-3ce6-8a5d-909f98c8819f,"Australia, Western Australia",,Subdivisions,AU-WA,-25.46,122.17
+7d0db380-a5b9-3a8b-a1da-0bca241abda1,Austria,,Country,AT,47.58,14.13
+cc8c0a97-c2df-3d73-8aff-160b65aa39e2,Azerbaijan,,Country,AZ,40.28,47.54
+7c9df801-238a-3e28-8ae2-675fd3166a1a,Bahamas (the),,Country,BS,24.22,-76.55
+c08bba7a-0c03-36f1-951e-8474d853ecbf,Bahrain,,Country,BH,26.03,50.56
+cfd7a475-f752-3ef8-95e8-d042c4511dd3,Bajo Nuevo Bank (Petrel Is.),,Miscellaneous,Bajo Nuevo Bank (Petrel Is.),15.79,-79.98
+c419b06b-4c65-39b5-8ff0-5adb3b8424f1,Bangladesh,,Country,BD,23.84,90.24
+21ad0bd8-36b9-3d08-b4cf-640b4c298e7c,Barbados,,Country,BB,13.18,-59.56
+df3f079d-e696-3496-b046-0dcfdbf9bca3,Belarus,,Country,BY,53.53,28.03
+910955a9-07e7-39b8-9ec8-855763108a29,Belgium,,Country,BE,50.63,4.63
+b005ad12-9444-3268-8084-f19bf5e19729,Belize,,Country,BZ,17.2,-88.69
+39b9df3a-0fb3-356d-91a6-3e22260e96ab,Benin,,Country,BJ,9.64,2.32
+08424385-5820-39ca-87f4-66f645784636,Bermuda,,Country,BM,32.31,-64.76
+69206263-69b1-3058-84f5-e3d6f93b5f6e,Bhutan,,Country,BT,27.42,90.4
+ad7532d5-b386-3a40-8fbe-01f9455dca36,Bolivia (Plurinational State of),,Country,BO,-16.7,-64.68
+52196aa5-4f16-34f9-acbf-26439c42c763,"Bonaire, Sint Eustatius and Saba",,Country,BQ,12.66,-67.81
+f70fa700-d983-397a-a43d-b99e1c1bc6a5,"Bonaire, Sint Eustatius and Saba, Saba",,Miscellaneous,BQ-SB,12.66,-67.81
+549bdb57-08be-322f-9b63-882851fbb84e,"Bonaire, Sint Eustatius and Saba, Sint Eustatius",,Miscellaneous,BQ-SE,12.66,-67.81
+07159c47-ee1b-39ae-8fb9-c40d480856c4,Bosnia and Herzegovina,,Country,BA,44.17,17.77
+823355b6-3ab3-3f0a-8e4d-1367e89abd1c,Botswana,,Country,BW,-22.18,23.79
+121aa3ee-4a7d-3b1b-bbc7-60fd0c6de79b,Bouvet Island,,Country,BV,-54.41,3.41
+dc634e20-7282-3fe0-b5be-9a2063390544,Brazil,,Country,BR,-10.78,-53.09
+251a2d08-d031-4589-9318-029ba543abde,"Brazil, Acre",,Subdivisions,BR-AC,-9.29,-70.47
+4c05bd06-d401-45cd-b594-c1eafa0ef95b,"Brazil, Alagoas",,Subdivisions,BR-AL,-9.51,-36.62
+744e0bff-1149-4c95-bea7-74792bc71a21,"Brazil, Amapa",,Subdivisions,BR-AP,1.45,-51.96
+12e2f855-d67d-492c-b59d-12205eeb79ea,"Brazil, Amazonas",,Subdivisions,BR-AM,-4.18,-64.71
+929f1a52-bb4d-4a86-8439-6b01d8813196,"Brazil, Bahia",,Subdivisions,BR-BA,-12.47,-41.7
+dc8836a3-1d91-49ed-b4b7-0482f7ec3eaf,"Brazil, Ceara",,Subdivisions,BR-CE,-5.09,-39.62
+c65371a5-fd9a-4ca9-ae24-c4fde6615445,"Brazil, Distrito Federal",,Subdivisions,BR-DF,-15.77,-47.78
+5d8ac1db-f842-4688-aba1-673c4f07b1dd,"Brazil, Espirito Santo",,Subdivisions,BR-ES,-19.56,-40.66
+1a3d1ef6-b2f8-44b8-b51a-c82dec5f769b,"Brazil, Goias",,Subdivisions,BR-GO,-16.02,-49.6
+6eaa35ce-47d2-4c3d-9079-12adc7ffb375,"Brazil, Maranhao",,Subdivisions,BR-MA,-5.09,-45.28
+64441fa1-0151-47ac-b97a-1fd886b90cae,"Brazil, Mato Grosso",,Subdivisions,BR-MT,-12.96,-55.92
+23baa40a-53e2-4d6c-a61e-a412c2b7aaae,"Brazil, Mato Grosso do Sul",,Subdivisions,BR-MS,-20.33,-54.84
+6e1c02cc-e7fc-4e63-a30e-59cfa5c4d9c1,"Brazil, Mid-western grid",,Electricity,BR-Mid-western grid,-15.3,-54.3
+00e9e1a4-0cf8-4f07-8bad-fd782ed54382,"Brazil, Minas Gerais",,Subdivisions,BR-MG,-18.45,-44.67
+3ece4ff8-55ae-40b2-baea-0d2bf2034fbf,"Brazil, North-eastern grid",,Electricity,BR-North-eastern grid,-8.63,-41.72
+572aa631-8a25-4c16-b437-2ee0672c450d,"Brazil, Northern grid",,Electricity,BR-Northern grid,-4.63,-59.25
+9a205fd8-72f3-423f-b3a7-6b805aaee30b,"Brazil, Para",,Subdivisions,BR-PA,-4.04,-53.13
+717c6f47-2eda-4d1b-8277-83f634ea7c23,"Brazil, Paraiba",,Subdivisions,BR-PB,-7.11,-36.82
+3b2c2140-c25c-47c5-876d-78e5dc82f066,"Brazil, Parana",,Subdivisions,BR-PR,-24.63,-51.63
+a64ba70d-b110-4f81-b415-299c0c193faa,"Brazil, Pernambuco",,Subdivisions,BR-PE,-8.33,-37.99
+70c9eee0-7dc4-4e2f-8dcc-f6bc4358ead9,"Brazil, Piaui",,Subdivisions,BR-PI,-7.41,-42.98
+862723a2-2563-490a-9b7a-7206cb46fcb1,"Brazil, Rio de Janeiro",,Subdivisions,BR-RJ,-22.19,-42.66
+8cd18b82-fdd2-4cf9-87c8-33e125b675f4,"Brazil, Rio Grande do Norte",,Subdivisions,BR-RN,-5.83,-36.67
+2248c6cf-f68d-4dac-85bb-fac7e80064f6,"Brazil, Rio Grande do Sul",,Subdivisions,BR-RS,-29.73,-53.31
+d9497730-f613-4d31-aab2-1d82add2d1bc,"Brazil, Rondonia",,Subdivisions,BR-RO,-10.91,-62.84
+2a7e9ed2-4de5-4b28-9b4e-b12c50a1ed53,"Brazil, Roraima",,Subdivisions,BR-RR,2.06,-61.4
+4645f771-3596-4c42-ba0f-822d1ce2fb72,"Brazil, Santa Catarina",,Subdivisions,BR-SC,-27.24,-50.48
+a7ba1868-375a-4d62-9048-bdf2136447c4,"Brazil, Sao Paulo",,Subdivisions,BR-SP,-22.26,-48.72
+17a40e27-7f28-48c3-892d-6121e748ed01,"Brazil, Sergipe",,Subdivisions,BR-SE,-10.57,-37.44
+7e6d7407-6a88-50d1-8f56-eb53f1c12102,"Brazil, South-eastern and Mid-western grid",,Electricity,"Brazil, South-eastern and Mid-western grid",-16.94,-51.03
+df7d08ae-6f20-4095-96e6-3d9cc6f49263,"Brazil, South-eastern grid",,Electricity,BR-South-eastern grid,-19.72,-45.48
+dd2330a8-30dc-4af9-bb3a-d2d2bf404dde,"Brazil, Southern grid",,Electricity,BR-Southern grid,-27.57,-52.26
+54e71d4b-1d1f-473d-91db-15d40c496a6d,"Brazil, Tocantins",,Subdivisions,BR-TO,-10.14,-48.32
+f98ed07a-4d5f-30f7-9e14-10d905f1477f,British Indian Ocean Territory (the),,Country,IO,-7.14,72.29
+4e58188f-f528-3ea1-aec7-38fffc0e118d,Brunei Darussalam,,Country,BN,4.51,114.72
+5523c88d-d347-31b7-8c61-7f632b7efdb7,Bulgaria,,Country,BG,42.76,25.21
+c9f9d7dd-806c-3412-a041-837a80f47c64,Burkina Faso,,Country,BF,12.26,-1.75
+99d4fb3d-b156-3c87-9a2c-dfc0158b37c3,Burundi,,Country,BI,-3.35,29.87
+de3ec0aa-2234-3a1e-bee2-75bbc715c6c9,Cabo Verde,,Country,CV,15.94,-23.97
+fa46ec0b-4924-38c2-994a-53ef61b94039,Cambodia,,Country,KH,12.71,104.9
+820eb5b6-96ea-3a65-bc0d-b1e258dc7d81,Cameroon,,Country,CM,5.69,12.73
+5435c69e-d3bc-35b2-a4d5-80e393e373d3,Canada,,Country,CA,61.37,-98.29
+546c1bd3-1f98-3d06-b407-1a7319f0ca71,Canada without Alberta,,Cutout,Canada without Alberta,61.74,-97.34
+9a0db1a8-1866-3aaa-9f25-881d425e2981,Canada without Alberta and Quebec,,Cutout,Canada without Alberta and Quebec,62.96,-101.08
+042dd99e-b0ff-3653-814e-445ca0093427,Canada without Quebec,,Cutout,Canada without Quebec,62.47,-101.92
+888ae6c0-9317-341c-86a4-6bfdf09b72fa,"Canada, Alberta",,Subdivisions,CA-AB,55.16,-114.5
+391d04b7-aa3e-3b93-9d1f-4d14740ef5f7,"Canada, British Columbia",,Subdivisions,CA-BC,54.76,-124.75
+e2494db3-71b1-310e-bc75-5ff220d01c47,"Canada, Manitoba",,Subdivisions,CA-MB,54.92,-97.43
+aa44e6fb-24ea-30f5-9463-91346594e4e8,"Canada, New Brunswick",,Subdivisions,CA-NB,46.62,-66.37
+2d3a62fe-4d77-3861-9a5d-b0ba1452a7bc,"Canada, Newfoundland and Labrador",,Subdivisions,CA-NL,52.87,-60.51
+bef33c35-d56a-3154-a9e2-b20a11d7580f,"Canada, Northwest Territories",,Subdivisions,CA-NT,66.35,-119.01
+c4f314d4-d365-310d-89a0-42946be99544,"Canada, Nova Scotia",,Subdivisions,CA-NS,45.15,-63.31
+c290d478-7431-3b6d-8372-325203b55c32,"Canada, Nunavut",,Subdivisions,CA-NU,71.02,-88.89
+5bd185b8-bc04-31d4-8307-5955dc838694,"Canada, Ontario",,Subdivisions,CA-ON,50.06,-85.82
+24213e9e-14b7-3f9c-be7d-189643518a9d,"Canada, Prince Edward Island",,Subdivisions,CA-PE,46.4,-63.24
+868a66d1-7428-4ba2-9125-253b07afc119,"Canada, Quebec",,Subdivisions,CA-QC,53.38,-71.78
+6108d9a8-6ab3-3a57-b470-a194c15a1d16,"Canada, Saskatchewan",,Subdivisions,CA-SK,54.41,-105.89
+11c42ab9-2538-3eb1-b665-6076cee71221,"Canada, Yukon",,Subdivisions,CA-YT,63.63,-135.51
+e7d76f14-42a7-3fc0-bec2-21a3f18683d1,Canary Islands,,Miscellaneous,ES-CN,28.33,-15.67
+288ea1e1-79de-3bc8-8a29-958f9857d9d1,Caribbean,,Global,UN-CARIBBEAN,20.15,-74.9
+9e854e58-6592-3fe3-961f-e89d56220808,Cayman Islands (the),,Country,KY,19.42,-80.87
+4e29342d-9904-364e-9e25-fd3b92558e2f,Central African Republic (the),,Country,CF,6.56,20.46
+41f3dc5d-9734-339d-86ad-47fe2970dfe0,Central America,,Global,UN-CAMERICA,21.81,-99.25
+8b6ba8a9-5220-3f57-8627-6e64a0f1cb40,Central and Eastern Europe,,Global,EEU,0.0,0.0
+f60425bb-5d9d-361c-8365-b042007676c0,Central Asia,,Global,CAS,45.91,66.46
+f114427f-29d0-3a63-9781-f1cc950e138e,Centrally Planned Asia and China,,Global,CPA,0.0,0.0
+626726e6-0bd1-315f-b671-9a308a25b798,Chad,,Country,TD,15.33,18.64
+161747ec-4dc9-355f-9760-195593742232,Chile,,Country,CL,-37.74,-71.36
+7efdfc94-655a-35dc-aa3e-c85e9bb703fa,China,,Country,CN,36.55,103.83
+5874165e-031e-4e85-ab69-8c2ae6a1a970,China without Inner Mongol,,Cutout,China without Inner Mongol,35.38,102.25
+b89fbb5e-5b12-3fbf-84e0-dde2a1af83e7,"China, Anhui (安徽)",,Subdivisions,CN-AH,31.82,117.22
+0c3eee87-5877-3e08-bafd-45af750ca0b8,"China, Beijing (北京)",,Subdivisions,CN-BJ,40.17,116.4
+f6298475-5b7f-5c28-9885-2338946a6cd6,"China, Central Grid",,Electricity,CN-CCG,30.58,107.94
+4c4a60a5-a0d5-369e-ad35-c23714845ace,"China, China Southern Power Grid",,Electricity,CN-CSG,24.56,106.46
+560cccf0-0b87-306f-bffd-5836e1175a7a,"China, Chongqing (重庆)",,Subdivisions,CN-CQ,30.05,107.85
+b6ec5424-a43b-5e34-a8ca-f35abb031049,"China, East Grid",,Electricity,CN-ECGC,29.43,117.82
+f15daa22-c911-3f89-ba04-2f020804afd5,"China, Fujian (福建)",,Subdivisions,CN-FJ,26.07,117.97
+10a33d7b-6e2e-3aa5-8dee-a126f06ae6c1,"China, Gansu (甘肃)",,Subdivisions,CN-GS,37.82,100.92
+e0da2e3f-1c41-368e-b7f1-d1aa54166975,"China, Guangdong (广东)",,Subdivisions,CN-GD,23.35,113.42
+e66b9cb6-fca6-3058-b3fc-ab1eea7e2162,"China, Guangxi (广西壮族自治区)",,Subdivisions,CN-GX,23.83,108.77
+a0e80568-b717-32ee-ac16-0fb0030b51cd,"China, Guizhou (贵州)",,Subdivisions,CN-GZ,26.81,106.87
+c7439785-e07d-3db1-a531-12b8a73fb9c2,"China, Hainan (海南)",,Subdivisions,CN-HI,19.19,109.74
+8f697344-3337-3a4d-a98b-fb261935fd20,"China, Hebei (河北)",,Subdivisions,CN-HE,39.55,116.12
+e40e7f95-3d17-3bfe-bd65-a885f2088578,"China, Heilongjiang (黑龙江省)",,Subdivisions,CN-HL,47.87,127.74
+37c4a9b5-5f7d-3238-bb72-4623cde79d2a,"China, Henan (河南)",,Subdivisions,CN-HA,33.88,113.6
+60418cbc-6847-3b06-a830-253aa9bd9dba,"China, Hubei (湖北)",,Subdivisions,CN-HB,30.97,112.26
+7bbc9d94-7ed7-3d7a-9953-f020aa8fa299,"China, Hunan (湖南)",,Subdivisions,CN-HN,27.61,111.69
+1e9be3c3-b260-37d5-8199-be20ff6cc65f,"China, Jiangsu (江苏)",,Subdivisions,CN-JS,32.97,119.44
+8f93bdbf-02dd-37f2-9c94-15b7adb0520c,"China, Jiangxi (江西)",,Subdivisions,CN-JX,27.61,115.71
+5cb7fbc5-6a92-345e-9b8c-205b7d56e247,"China, Jilin (吉林)",,Subdivisions,CN-JL,43.67,126.17
+b6c0a73a-ad7d-352e-a96f-0e22769d89d5,"China, Liaoning (辽宁)",,Subdivisions,CN-LN,41.3,122.61
+94f8eaf5-2a69-3408-a868-564ba00a53e9,"China, Nei Mongol (内蒙古自治区)",,Subdivisions,CN-NM,44.08,113.9
+fc88ecd5-d3d6-3669-a708-4b9a86e8907d,"China, Ningxia (宁夏回族自治区)",,Subdivisions,CN-NX,37.26,106.16
+ae30ab76-bfa2-59fb-bccc-1ad0246cd7b3,"China, North Grid",,Electricity,CN-NCGC,42.29,114.41
+f0894a96-367f-5327-bc91-e156fdb6a5c7,"China, Northeast Grid",,Electricity,CN-NECG,45.76,126.49
+fa7f6c22-bd54-58c5-a8f0-0939ace8b856,"China, Northwest Grid",,Electricity,CN-NWG,39.0,91.62
+8091cd9d-b8ec-3623-a5a2-5b61ea85eb98,"China, Qinghai (青海)",,Subdivisions,CN-QH,35.74,96.0
+442e473c-81d4-34e6-a31e-a13d33c939af,"China, Shaanxi (陕西)",,Subdivisions,CN-SN,35.18,108.86
+21f95e96-39a6-3597-9376-f920757c6fb3,"China, Shandong (山东)",,Subdivisions,CN-SD,36.35,118.15
+26f19341-0269-3662-9c33-6561ad91237f,"China, Shanghai (上海)",,Subdivisions,CN-SH,31.18,121.44
+61ca6a75-802d-39f2-b7b3-09767d6389e0,"China, Shanxi (山西)",,Subdivisions,CN-SX,37.57,112.28
+3ea7c4c6-7057-3b39-96e1-a3251dda63b2,"China, Sichuan (四川)",,Subdivisions,CN-SC,30.61,102.7
+094ba255-b84b-5fbd-8c8a-75547f362075,"China, Southwest Grid",,Electricity,CN-SWG,31.68,88.11
+6515e168-6762-351f-b146-9deb97414906,"China, State Grid Corporation of China",,Electricity,CN-SGCC,37.8,103.55
+267b1b52-9830-3ddd-bce9-0be0b80a70ec,"China, Tianjin (天津)",,Subdivisions,CN-TJ,39.29,117.31
+524dc282-e858-3e44-b59c-05a258bde0bd,"China, Xinjiang (新疆维吾尔自治区)",,Subdivisions,CN-XJ,41.09,85.18
+7b09132e-4f69-3321-b69f-fbaafccb926a,"China, Xizang (西藏自治区)",,Subdivisions,CN-XZ,31.68,88.11
+9825d889-e0ea-346a-8a60-09d9de7ad000,"China, Yunnan (云南)",,Subdivisions,CN-YN,24.97,101.47
+e22dbdd9-06f5-3598-accc-59c8ff842535,"China, Zhejiang (浙江)",,Subdivisions,CN-ZJ,29.17,120.07
+0bdff809-5c8b-31b3-8775-bf35547a1317,Christmas Island,,Country,CX,-10.49,105.66
+8c37ce4b-665f-30ac-abb4-0fd2a3c43b04,Churchill Falls Generating Station,,Miscellaneous,Churchill Falls Generating Station,53.52,-63.99
+8f775bae-e910-3a54-8541-f4a49f87b2f2,Clipperton Island,,Miscellaneous,FR-CP,10.29,-109.22
+e0323a90-39ad-3297-8bf5-b49550572c7c,Cocos (Keeling) Islands (the),,Country,CC,-12.17,96.86
+ab6c0400-6660-3ef2-919d-512b21dce9ab,Colombia,,Country,CO,3.9,-73.08
+f9180cb9-286c-39c4-b3a6-c793798b9ddf,Commonwealth of Independent States,,Miscellaneous,CIS,59.95,92.26
+9b05de73-d43f-3c4e-8111-0c6bcc5312bc,Comoros (the),,Country,KM,-11.88,43.68
+6865aeb3-a9ed-38f9-a79e-c454b259e5d0,Congo (the Democratic Republic of the),,Country,CD,-2.87,23.64
+6e9cf3ee-f65d-3697-b96c-f33f27eb0f57,Congo (the),,Country,CG,-0.83,15.21
+d5a5b3dd-1ccb-30d3-8360-f0c068fd43fc,Cook Islands (the),,Country,CK,-19.81,-158.79
+6bb17796-0cff-3545-9414-6bd0821b4560,Coral Sea Islands,,Miscellaneous,AU-CR,-18.52,151.27
+324d8a1d-3f81-3730-9509-9a48cee0c5b6,Costa Rica,,Country,CR,9.97,-84.19
+adab7b70-1f23-3b82-814c-8506d3dc784e,Croatia,,Country,HR,45.06,16.39
+a4dbfd6a-ef3b-3045-be61-aa0146debdf8,Cuba,,Country,CU,21.62,-79.03
+0707ba09-2e91-360b-b05c-326e6a353593,Curaçao,,Country,CW,12.19,-68.97
+471c1f3f-c1dd-3bb8-8d03-41b03e4be59e,Cyprus,,Country,CY,34.91,32.98
+b40feb9f-0afa-3eab-9c03-5085ecbbb908,Cyprus No Mans Area,,Miscellaneous,Cyprus No Mans Area,35.1,33.25
+9c049173-fad5-34f8-9c68-231237df85b8,Czechia,,Country,CZ,49.73,15.31
+35ea51ba-f1fe-3f01-82ad-5f950855dde0,Côte d'Ivoire,,Country,CI,7.62,-5.56
+0ecbf942-6bcf-3d9a-886d-ed5fc8c4eca8,Denmark,,Country,DK,55.96,10.05
+2a552811-5dc6-3462-a113-dda562233bd7,Dhekelia Sovereign Base Area,,Miscellaneous,Dhekelia Sovereign Base Area,35.01,33.79
+64ca6097-2a6e-3926-91c4-b9d31080c687,Djibouti,,Country,DJ,11.75,42.56
+608e7dc1-16de-3157-b060-12b4f0be82ac,Dominica,,Country,DM,15.43,-61.35
+d4579b26-88d6-3523-9f40-2f6b4b43bcbf,Dominican Republic (the),,Country,DO,18.89,-70.49
+e110324f-3d3c-3394-a6f8-f87e742dcaa4,Eastern Africa,,Global,UN-EAFRICA,-4.37,36.48
+95b09ece-0ccc-3fa4-89f0-ef29d63c6dbe,Eastern Asia,,Global,UN-EASIA,38.17,105.29
+db28a51a-61d7-3b0b-bb5c-a1c0a25db72e,Eastern Europe,,Global,UN-EEUROPE,61.13,91.92
+2f53e6f3-f2ac-3041-a4e0-737e58c45321,Ecuador,,Country,EC,-1.42,-78.77
+2a6a84e9-e444-31af-bd75-cc19ce28be37,Egypt,,Country,EG,26.49,29.86
+74354112-1c12-3113-af80-7d1582c74bea,El Salvador,,Country,SV,13.73,-88.87
+b84a1ed8-db3d-3bf3-b8f4-9becdea153b2,Equatorial Guinea,,Country,GQ,1.7,10.33
+818f9c45-cfa3-3eef-b277-ef38bcbe9910,Eritrea,,Country,ER,15.35,38.85
+08a4415e-9d59-3ff9-a003-0b921d42b91e,Estonia,,Country,EE,58.67,25.53
+7dabf5c1-98b0-3ab2-aaa4-2bb03a113e55,Eswatini,,Country,SZ,-26.56,31.48
+4de1b7a4-dc53-34a8-8c25-ffb7cdb580ee,Ethiopia,,Country,ET,8.62,39.6
+9813077a-1292-3b9e-9da5-bd55fa33ecb6,EU Associated Countries 2005,,Miscellaneous,EU-AC2005,0.0,0.0
+b3c26978-fa5b-3e96-998d-3d5eb0cce441,EU Associated Countries 2007,,Miscellaneous,EU-AC2007,0.0,0.0
+1a88a0a3-7c7f-3bac-96c8-988fe871a18d,EU Candidate Countries 2005,,Miscellaneous,EC-CC2005,0.0,0.0
+0273c379-31a2-34e3-9d4a-351b4c0f4ef2,EU Candidate Countries 2007,,Miscellaneous,EC-CC2007,0.0,0.0
+1981f919-7ad2-31d5-8748-b520285f6323,EU New Member Countries 2004,,Miscellaneous,EU-NMC2004,0.0,0.0
+c1717bc2-161f-3b18-90d6-80e24878d689,EU-15 European Union,,Miscellaneous,EU15,0.0,0.0
+70262596-fdf2-327d-b787-12fb738a9270,EU-25 European Union,,Miscellaneous,EU25,0.0,0.0
+80e68c50-5cf3-3f11-b809-f8cfbd9a4b17,EU-25 European Union and Candidate Countries 2005,,Miscellaneous,EU25-CC2005,0.0,0.0
+d5ef8373-2ea8-3c9b-9fb5-4f8cb68a9714,EU-25 European Union and Candidate Countries 2005 and Associated Countries 2005,,Miscellaneous,EU25-CC2005-AC2005,0.0,0.0
+5c7f219e-57db-3579-a019-27fb8995651b,EU-27 European Union,,Miscellaneous,EU27,0.0,0.0
+322eb489-99c8-380b-8870-87c8d2e958a2,EU-27 European Union and Candidate Countries 2007,,Miscellaneous,EU27-CC2007,0.0,0.0
+aef4c4e7-71b3-3811-876f-5a31fbf8eb0e,EU-27 European Union and Candidate Countries 2007 and Associated Countries 2007,,Miscellaneous,EU27-CC2007-AC2007,0.0,0.0
+d66c264e-1dbd-33e6-911d-3ffc70908e8e,Europe,,Global,RER,55.89,28.11
+67c114d5-d361-4466-a5e7-fc21c498a254,Europe without Austria,,Cutout,Europe without Austria,55.95,28.21
+06e2458b-3178-3438-b3f4-84051244c27d,"Europe without Austria, Belgium, France, Germany, Italy, Liechtenstein, Monaco, San Marino, Switzerland, and the Vatican",,Cutout,"Europe without Austria, Belgium, France, Germany, Italy, Liechtenstein, Monaco, San Marino, Switzerland, and the Vatican",56.99,30.72
+5d5718f2-ee74-462a-888c-be4d534ef542,Europe without Germany and Switzerland,,Cutout,Europe without Germany and Switzerland,56.08,28.77
+ae85cec6-cc61-4a0d-a322-5fb10b6b4ece,"Europe without Germany, Netherlands, Norway",,Cutout,"Europe without Germany, Netherlands, Norway",55.72,29.53
+8bd484ff-ec4e-45c6-9f61-e211a872a4ff,"Europe without Germany, Netherlands, Norway, Russia",,Cutout,"Europe without Germany, Netherlands, Norway, Russia",52.47,14.88
+5c322a16-89ab-48d4-b1a2-fec5759774a3,"Europe without Germany, Netherlands, Russia",,Cutout,"Europe without Germany, Netherlands, Russia",53.42,14.82
+e6a1bb9b-c1f3-49ed-a64b-87d488244ef9,Europe without Russia,,Cutout,Europe without Russia,53.28,14.51
+817ed804-f0ed-3175-b39d-7576a1c242b1,Europe without Switzerland,,Cutout,Europe without Switzerland,55.92,28.18
+f4f87f1d-101c-4b43-b2de-f646734ae9fe,Europe without Switzerland and Austria,,Cutout,Europe without Switzerland and Austria,55.98,28.28
+6a1e0054-4990-4d43-b7e4-e3d9a595a275,Europe without Switzerland and France,,Cutout,Europe without Switzerland and France,56.36,29.39
+b380c952-746f-3cf9-89ae-d6562c7ee132,"Europe, Baltic System Operator",,Electricity,BALTSO,56.8,24.71
+35c302ef-c91c-31e9-a4e6-490bbe01a06f,"Europe, Central European Power Association",,Electricity,CENTREL,50.67,18.81
+c93762d2-a7a3-335c-81c2-fa0be65506df,"Europe, Europe with NORDEL",,Electricity,Europe with NORDEL,54.06,29.67
+a2d4e588-e0d1-11de-823b-0019e336be3a,"Europe, Europe without NORDEL",,Electricity,Europe without NORDEL,54.44,30.4
+8ebf61e1-cf59-357c-b93d-225d0ccb7181,"Europe, European Network of Transmission Systems Operators for Electricity",,Electricity,ENTSO-E,53.78,12.18
+4205164e-e2e5-30d6-98fb-7657af40aed6,"Europe, Nordic Countries Power Association",,Electricity,NORDEL,63.75,18.86
+e743b51e-41f8-3369-9418-34177c8f34e7,"Europe, UCTE without France",,Electricity,UCTE without France,45.99,12.44
+cdba052d-e53c-3173-b857-3d555fad2c16,"Europe, UCTE without Germany",,Electricity,UCTE without Germany,45.41,10.85
+8dc6a685-44c9-3a1c-b937-78a6de2d9830,"Europe, UCTE without Germany and France",,Electricity,UCTE without Germany and France,45.14,12.79
+1e11ad8e-d46d-368b-9ef5-a43e99dec543,"Europe, UN Region",,Global,UN-EUROPE,60.1,78.92
+b633c174-f67b-3819-a2a4-ef89f2d5b8cb,"Europe, Union for the Co-ordination of Transmission of Electricity",,Electricity,UCTE,46.09,10.79
+73ecfbb1-f6be-3c1e-b05a-aca2cb5b216d,"Europe, without Russia and Türkiye",,Cutout,Europe without Russia and Türkiye,53.28,14.51
+ef1cb6e7-2d14-3b18-8cc2-41037203f60b,Falkland Islands (the),,Country,FK,-51.73,-59.37
+eed80702-4939-3808-883f-0031a56e9872,Faroe Islands (the),,Country,FO,62.07,-6.87
+6fac3ab6-03bb-3fb4-ae42-77786393194c,Fiji,,Country,FJ,-17.44,163.4
+75778bf8-fde7-366d-816b-0089e7b8b793,Finland,,Country,FI,64.49,26.27
+190aeb66-f132-3e93-995a-70e36f3431c5,Former Soviet Union,,Miscellaneous,Former Soviet Union,59.95,92.26
+82a9e4d2-6595-387a-b6e4-42391d8c5bba,France,,Country,FR,46.55,2.54
+c4f57fe2-5b64-3193-8cfd-d118f11e9024,"France, including overseas territories",,Miscellaneous,"France, including overseas territories",41.05,-1.86
+e5bb2379-7bfe-3314-a3db-43d07dbd6a74,French Guiana,,Country,GF,3.92,-53.24
+7287aa2c-53d0-3440-9a9d-b5614937e36f,French Polynesia,,Country,PF,-15.18,-145.05
+114d6a41-5b3d-34db-b92c-a7c0da0c7a55,French Southern Territories (the),,Country,TF,-49.06,68.99
+32d7508f-e692-30cb-80af-28441ef746d9,Gabon,,Country,GA,-0.59,11.78
+92073d2f-e26e-343c-a222-cc0fb0b7d7a0,Gambia (the),,Country,GM,13.44,-15.39
+0ba64a0d-ea00-3479-96df-b6a66866e1ca,Georgia,,Country,GE,42.16,43.5
+5f02f088-9301-3d7b-a1ac-972c11bf3e7d,Germany,,Country,DE,51.1,10.38
+19b19ffc-30ca-3f1c-9376-cd2982992a59,Ghana,,Country,GH,7.95,-1.21
+28dd376c-5a44-3cc9-ae45-0ee338260c56,Gibraltar,,Country,GI,36.12,-5.34
+56bca136-90bb-3a77-9abb-7ce558af711e,Global,,Unlocated,GLO,0.0,0.0
+d692bc40-d834-33d2-8d3a-37582f58468c,Greece,,Country,GR,39.05,22.97
+ce1d5a24-80e0-34a2-91c1-c7968cc66c13,Greenland,,Country,GL,74.73,-41.34
+a6be8a33-b7c9-37f4-bfb7-6d9c9805c7eb,Grenada,,Country,GD,12.15,-61.65
+5343b21a-d303-3f17-9962-9894deca13db,Guadeloupe,,Country,GP,16.2,-61.52
+d2a460df-08a4-3b7a-958f-635b540d90cb,Guam,,Country,GU,13.44,144.77
+1bfad22f-0925-378f-b10a-37440bfdff43,Guatemala,,Country,GT,15.69,-90.36
+73c18c59-a39b-3838-a081-ec00bb456d43,Guernsey,,Country,GG,49.48,-2.53
+5123dd8b-087b-344f-9b8f-8603acd1bad4,Guinea,,Country,GN,10.43,-10.94
+3f071f4f-163d-3855-9f4f-c1544c7f69a6,Guinea-Bissau,,Country,GW,12.02,-14.97
+5e08be98-8691-354c-937b-997b4cb6ad97,Guyana,,Country,GY,4.79,-58.98
+eb5e48e7-4123-3acc-9276-1302ea4a7d22,Haiti,,Country,HT,18.93,-72.69
+2ab5564b-805d-3065-b4bc-f81060472746,Heard Island and McDonald Islands,,Country,HM,-53.08,73.5
+43b1cc1d-b7be-33d8-99dd-4280f578691a,Holy See (the),,Country,VA,41.9,12.45
+59ca4f8b-bb97-33c2-ab59-db115fcdb664,Honduras,,Country,HN,14.82,-86.62
+ae417185-6a75-37b6-bd51-fc0e1f95902e,Hong Kong,,Country,HK,22.38,114.13
+18bd9197-cb1d-333b-8352-f47535c00320,Hungary,,Country,HU,47.16,19.39
+31c68c64-6657-3dcc-bc06-2d977c76315b,"IAI Area, Africa",,Aluminium,"IAI Area, Africa",-2.34,22.31
+60a4d810-df1e-3895-95b4-025bbedca798,"IAI Area, Asia, without China and GCC",,Aluminium,"IAI Area, Asia, without China and GCC",30.78,76.41
+a2788633-a453-37e8-ac1d-c6c5b63300b2,"IAI Area, EU27 & EFTA",,Aluminium,"IAI Area, EU27 & EFTA",52.47,8.4
+a335f1f7-79cd-311f-b82e-33648aa17cd3,"IAI Area, Gulf Cooperation Council",,Aluminium,"IAI Area, Gulf Cooperation Council",21.35,55.61
+cf7ec575-43e5-3274-8c54-1e9ec72461bd,"IAI Area, North America",,Aluminium,"IAI Area, North America",55.13,-103.93
+af92823f-638d-36d7-8406-451a58f61543,"IAI Area, North America, without Quebec",,Aluminium,"IAI Area, North America, without Quebec",55.27,-106.45
+15b95f69-f97e-36b9-a54e-905eff9c2bdb,"IAI Area, Russia & Europe outside EU27 & EFTA",,Aluminium,"IAI Area, Russia & Europe outside EU27 & EFTA",61.93,96.49
+8364be66-e49f-36e8-8ea4-a8795d469fe3,"IAI Area, South America",,Aluminium,"IAI Area, South America",-15.97,-57.18
+a2a551a6-458a-3de2-a446-cc76d639a9e9,Iceland,,Country,IS,64.99,-18.59
+13b5bfe9-6f3e-3fe4-91c9-f66f4a582adf,India,,Country,IN,22.88,79.6
+7661383e-998b-4738-b8dc-9e1e60070c8a,"India, Andaman and Nicobar Islands",,Subdivisions,IN-AN,11.13,92.97
+888f6bc1-22f6-486b-b2f3-814672df6930,"India, Andhra Pradesh",,Subdivisions,IN-AP,15.72,79.92
+28388907-7605-469a-b28d-cdc8f963b28b,"India, Arunachal Pradesh",,Subdivisions,IN-AR,28.03,94.66
+d0145549-5ad2-4cc6-8e5b-c6ed6223d2db,"India, Assam",,Subdivisions,IN-AS,26.35,92.83
+5ba6d534-2083-4167-975d-84579c9e5202,"India, Bihar",,Subdivisions,IN-BR,25.66,85.6
+1b5afe13-e071-4c8a-81b5-68eb8982053f,"India, Chandigarh",,Subdivisions,IN-CH,30.74,76.76
+89f88c37-befd-49fa-92ad-35875a6709eb,"India, Chhattisgarh",,Subdivisions,IN-CG,21.25,82.03
+d766dc54-3e8f-4ac4-8a0f-69707a338b33,"India, Dadra and Nagar Haveli",,Subdivisions,IN-DN,20.16,73.03
+653869da-6e3f-476e-9380-19d23040f2b9,"India, Daman and Diu",,Subdivisions,IN-DD,20.46,72.59
+de26c625-ae68-4c9e-8fde-a6c33b3dfe14,"India, Delhi",,Subdivisions,IN-DL,28.66,77.1
+1eb1f8b3-8c35-425e-94ca-cf502eb004c3,"India, Eastern grid",,Electricity,IN-Eastern grid,23.07,85.69
+567cc8ea-05d0-4d27-a509-89f10e1a280e,"India, Goa",,Subdivisions,IN-GA,15.35,74.04
+0d325613-94aa-4a65-8014-d3f6ead19eb3,"India, Gujarat",,Subdivisions,IN-GJ,22.71,71.55
+3f1442fa-0808-438c-a355-2a1e96f9adeb,"India, Haryana",,Subdivisions,IN-HR,29.2,76.33
+763ca99d-f561-45ef-8d36-84cb877f9c08,"India, Himachal Pradesh",,Subdivisions,IN-HP,31.93,77.22
+4a07e727-a1e5-4079-8433-b1d2b5ed544c,"India, Islands",,Electricity,IN-Islands,11.12,92.87
+d8cc1385-8b61-4509-8db0-d9cb5fa95725,"India, Jammu and Kashmir",,Subdivisions,IN-JK,33.55,75.07
+2221b78c-5a1c-454c-a637-744d54a0bbe9,"India, Jharkhand",,Subdivisions,IN-JH,23.64,85.53
+c23d9dc6-d794-4775-8e92-ee830a084a7f,"India, Karnataka",,Subdivisions,IN-KA,14.71,76.15
+518f1827-fe70-400e-b521-48f2f72fd777,"India, Kerala",,Subdivisions,IN-KL,10.42,76.42
+dee052a0-3714-41b6-86c0-79d062704c25,"India, Lakshadweep",,Subdivisions,IN-LD,10.12,72.82
+b3d19998-fe81-4783-a19e-408d7424d876,"India, Madhya Pradesh",,Subdivisions,IN-MP,23.53,78.29
+14bfff77-d5a0-4ad5-9936-58636c295e99,"India, Maharashtra",,Subdivisions,IN-MH,19.46,76.11
+d6bf166c-b5aa-45a6-b0e9-7c169d2c7cbc,"India, Manipur",,Subdivisions,IN-MN,24.73,93.86
+10988ebe-8be4-43c6-8451-3273ca12cd47,"India, Meghalaya",,Subdivisions,IN-ML,25.53,91.28
+cab4fbd7-e8ae-4ea6-9e74-0e41df667c61,"India, Mizoram",,Subdivisions,IN-MZ,23.29,92.81
+df16b2b2-c49e-4560-9b74-cbcbe0a8d281,"India, Nagaland",,Subdivisions,IN-NL,26.05,94.44
+26e353a9-dac6-4123-833d-75cd720d9e19,"India, North-eastern grid",,Electricity,IN-North-eastern grid,26.3,93.42
+59003ab7-b40a-43ac-b7c9-3e3e8907803e,"India, Northern grid",,Electricity,IN-Northern grid,28.51,76.71
+bf61f94b-cbd6-4a41-9c8b-0ef2b4e06c3c,"India, Odisha",,Subdivisions,IN-OD,20.51,84.41
+f7228566-0785-45da-b946-01f82d277dda,"India, Puducherry",,Subdivisions,IN-PY,11.96,78.88
+83cdc953-e485-453b-a8f9-749f92aca417,"India, Punjab",,Subdivisions,IN-PB,30.84,75.4
+4024933b-d7a2-4ebb-87dc-80460ff13c50,"India, Rajasthan",,Subdivisions,IN-RJ,26.59,73.83
+01c44dfa-113d-427b-81b9-1d4fde230f93,"India, Sikkim",,Subdivisions,IN-SK,27.57,88.44
+8a80d1d2-de76-44e0-a3d3-46b98c053ca1,"India, Southern grid",,Electricity,IN-Southern grid,14.53,78.11
+eb2442cf-93eb-4784-99f9-7a0c97c3576f,"India, Tamil Nadu",,Subdivisions,IN-TN,11.01,78.4
+001c936c-cf14-46dd-a99e-b1ef30f51c96,"India, Tripura",,Subdivisions,IN-TR,23.75,91.72
+ae2be714-8cbe-4abd-afac-a5e7ca2b0d55,"India, Uttar Pradesh",,Subdivisions,IN-UP,26.93,80.54
+6859dfd7-168b-4a36-9429-e0e884bff83a,"India, Uttarakhand",,Subdivisions,IN-UK,30.16,79.19
+77849b53-31ea-4b25-93e5-451909753ad3,"India, West Bengal",,Subdivisions,IN-WB,23.8,87.97
+25457a88-a525-4fd8-b73d-72fd3f37fc74,"India, Western grid",,Electricity,IN-Western grid,21.7,76.77
+14b3773a-9228-3ca1-98e3-3d0017100d23,Indian Ocean Territories,,Miscellaneous,AU-IOT,-10.69,104.61
+b80bb774-0288-3da1-b201-890375a60c8f,Indonesia,,Country,ID,-2.22,117.27
+d74eea48-99a6-3f9f-8bc5-27ef988ea0ff,Iran (Islamic Republic of),,Country,IR,32.57,54.27
+795237fd-9d10-3e63-8d19-b0db0f2fba2f,Iraq,,Country,IQ,33.03,43.74
+25400724-d737-3b0b-a9c9-369d9af3dd21,Ireland,,Country,IE,53.17,-8.14
+73bebce3-95b6-31ef-adcf-6842fbdb4d76,Isle of Man,,Country,IM,54.22,-4.53
+4605f628-f91d-321e-8b5f-9433f46e29eb,Israel,,Country,IL,31.44,34.99
+0d149b90-e739-3297-b01c-90191ae775f0,Italy,,Country,IT,42.78,12.07
+3da770cc-56ed-3407-b6aa-f10ad4e72b4d,Jamaica,,Country,JM,18.15,-77.31
+55add3d8-45bf-3d87-a9b0-949b0da49c0a,Japan,,Country,JP,37.55,137.97
+79563e90-630a-3352-9dff-01b6638b0886,Jersey,,Country,JE,49.22,-2.12
+1799e32a-b029-4981-ab1b-1cd932c1e64b,Jervis Bay Territory,,Miscellaneous,AU-JB,-35.15,150.7
+674f3384-1e23-39ff-9d24-c85dc3b999de,Jordan,,Country,JO,31.24,36.77
+9008f9e2-758f-38fe-920b-1765e72734d5,Kazakhstan,,Country,KZ,48.15,67.28
+25bc6654-798e-3508-ba0b-6343212a74fe,Kenya,,Country,KE,0.55,37.82
+988287f7-a1eb-366f-bc4e-19bdbdeec7c3,Kiribati,,Country,KI,0.8,-47.73
+26b568e4-192a-364d-9b3e-acdbd632bc2e,Korea (the Democratic People's Republic of),,Country,KP,40.15,127.18
+dcf0d7d2-cd12-3bf4-a580-d43f29785dd3,Korea (the Republic of),,Country,KR,36.37,127.81
+a2d8fced-03cb-3e20-af8e-1226935c9c92,Kosovo,,Miscellaneous,XK,42.57,20.87
+048685d9-6262-3854-82a1-d5bb4a14bc3b,Kuwait,,Country,KW,29.34,47.59
+ebe86682-666f-3ab3-9a08-43ed3097e4b3,Kyrgyzstan,,Country,KG,41.46,74.54
+c9089f3c-9ada-3018-af6f-fb1ee8d6501c,Lao People's Democratic Republic (the),,Country,LA,18.5,103.73
+84502834-6281-3742-9577-a349ea768503,Latin America and the Caribbean,,Global,RLA,-10.23,-65.65
+85d1a9c4-88d7-317e-a862-91a755e5d43c,Latvia,,Country,LV,56.85,24.9
+26403ec6-d537-3a31-b63e-294b44831734,Lebanon,,Country,LB,33.92,35.87
+44ba5ca6-5651-34f3-af19-27576dd35436,Lesotho,,Country,LS,-29.57,28.22
+58791f32-2c1b-3c3d-a614-1788d3b8666f,Liberia,,Country,LR,6.45,-9.31
+e728b477-51c6-3559-82cb-60f97d1e4553,Libya,,Country,LY,27.03,18.0
+d70c1e5d-44de-3a91-90eb-91ecff563578,Liechtenstein,,Country,LI,47.13,9.54
+d91af695-8918-3f87-96a0-57c1cdf5b225,Lithuania,,Country,LT,55.32,23.88
+3e7e122b-f08f-3843-ac96-1ba491089dc9,Luxembourg,,Country,LU,49.76,6.07
+27c9d518-7cd2-33f8-9160-ec1ed2b5ac89,Macao,,Country,MO,22.15,113.55
+b351bb9b-0af6-34fc-a787-49675c53ad67,Madagascar,,Country,MG,-19.37,46.7
+38fed710-7cee-3580-98ca-06304c1beb90,Malawi,,Country,MW,-13.21,34.28
+6864f389-d987-3436-bc87-78ff071d1b6c,Malaysia,,Country,MY,3.79,109.69
+94d03594-5b3d-3218-a669-c4d3f6daa104,Maldives,,Country,MV,3.82,73.3
+9830e1f8-1f62-3b33-906a-cc186b93374e,Mali,,Country,ML,17.34,-3.53
+710998fd-1b7c-3235-9702-65650770a4b1,Malta,,Country,MT,35.92,14.4
+ed8f5b7e-7439-3143-b43a-93dc753618ae,Marshall Islands (the),,Country,MH,7.11,170.09
+1d8a4975-693e-31eb-9ca5-4878098d608f,Martinique,,Country,MQ,14.65,-61.01
+d9394066-970e-34ae-a52f-d0347e58c03e,Mauritania,,Country,MR,20.25,-10.34
+89aa4b19-6b48-38a1-ba65-49bb1eaebd80,Mauritius,,Country,MU,-20.18,57.84
+fa0ed5b5-c600-345b-9d9a-299952b99651,Mayotte,,Country,YT,-12.81,45.14
+9c7e385f-c425-3258-a571-a94454d24b2b,Melanesia,,Global,UN-MELANESIA,-7.76,147.88
+3d26b0b1-7065-32cf-a9c0-6c010184c684,Mexico,,Country,MX,23.94,-102.53
+11a4769f-1f94-3ef6-9be6-a120cd4e3e67,Micronesia,,Global,UN-MICRONESIA,8.01,95.93
+0ab34ca9-7d99-3659-9bf8-9817789cb5de,Micronesia (Federated States of),,Country,FM,7.04,155.19
+e71864bf-656a-3133-8489-a428120c0ada,Middle Africa,,Global,UN-MAFRICA,0.61,19.46
+4b24ca1d-6a54-335b-811e-38a32aaa0967,Middle East,,Global,RME,28.63,48.65
+483bbc62-bf06-31a1-9aca-efa0a24e2f1e,Middle East and North Africa,,Global,MEA,28.63,34.24
+793914c9-c583-39d8-ad0f-4ed8c521b0c1,Moldova (the Republic of),,Country,MD,47.19,28.46
+d6fd0924-e324-3506-a9ae-0295adf59567,Monaco,,Country,MC,43.73,7.39
+41256636-7c67-348b-999d-1b7666f8ccfc,Mongolia,,Country,MN,46.82,103.05
+ab86a1e1-ef70-3ff9-b959-067b723c5c24,Montenegro,,Country,ME,42.78,19.23
+ee33e909-372d-335d-990f-4fcb2a92d542,Montserrat,,Country,MS,16.73,-62.18
+b74df323-e393-3b56-b635-a2cba7a7afba,Morocco,,Country,MA,29.84,-8.39
+4f3dd0ff-b3e4-3c5f-b4b5-b0d8c1f10bb5,Mozambique,,Country,MZ,-17.27,35.53
+b3cd915d-7580-38bd-99d0-f2428fbb354a,Myanmar,,Country,MM,21.16,96.48
+6ec66e12-4fb9-3c19-8e92-07b0b82f542a,Namibia,,Country,NA,-22.12,17.21
+0ab3e5d0-801a-3a3f-b758-bcbd812e8f10,Nauru,,Country,NR,-0.52,166.93
+40590d3d-1a34-3650-81f5-e48b08ef2096,Near East,,Global,RNE,33.72,39.81
+cf3fc916-339b-32ad-9c14-aca2425ccf53,Nepal,,Country,NP,28.24,83.91
+1a13105b-7e4e-35fb-ae7c-9515ac06aa48,Netherlands (Kingdom of the),,Country,NL,52.26,5.58
+18b049cc-8d85-3578-b929-df716f9f4e68,Netherlands Antilles,,Miscellaneous,AN,12.66,-67.81
+1e734284-5e24-3b3b-9b35-54490da1c128,New Caledonia,,Country,NC,-21.3,165.7
+c97b334f-fd41-3a49-9708-3f1949632bc1,New Zealand,,Country,NZ,-41.82,171.47
+e6c151d4-49e1-3b05-b1ff-b5ad5ec656cf,Nicaragua,,Country,NI,12.84,-85.03
+d4f91763-3649-33c4-bc7a-b917fa990146,Niger (the),,Country,NE,17.41,9.38
+66e10e9f-f65e-3479-a54d-de3968d3440d,Nigeria,,Country,NG,9.59,8.09
+0288bde0-c2d5-33f2-b576-6f61b826a650,Niue,,Country,NU,-19.04,-169.86
+78d9238c-1a21-3c8b-be8f-6c26172fb12d,Norfolk Island,,Country,NF,-29.03,167.95
+aab06382-a476-4bec-a78b-d2fc0b849980,North America without Quebec,,Cutout,North America without Quebec,55.27,-106.45
+d9a20693-e28e-33ac-aa03-8df3b3bfa273,"North America, Alaska Systems Coordinating Council",,Electricity,US-ASCC,64.26,-152.27
+679f547e-8973-3198-9562-f49522f5f5ac,"North America, Electric Reliability Council of Texas",,Electricity,US-ERCOT,31.1,-97.64
+d1e780c1-ae55-3086-82ed-b9f568342c46,"North America, Florida Reliability Coordinating Council",,Electricity,US-FRCC,28.34,-81.9
+add33b5c-114e-39e1-8996-ebe46366c661,"North America, Hawaii Power Grid",,Electricity,US-HICC,20.25,-156.35
+cda0fd29-18d1-3e20-ac87-1ed79a8d2bb0,"North America, Midwest Reliability Organization",,Electricity,MRO,48.38,-99.5
+8ce8d793-183f-312a-a33c-5c61ec31edb6,"North America, Midwest Reliability Organization, US part only",,Electricity,US-MRO,42.2,-97.41
+588c9ca2-d66d-3e43-b7b3-65bfd7e971cf,"North America, Northeast Power Coordinating Council",,Electricity,NPCC,51.08,-76.5
+50f826e7-ab13-444e-987b-180701b691c9,"North America, Northeast Power Coordinating Council, US part only",,Electricity,US-NPCC,43.69,-72.87
+6c68ef81-a341-3ab2-bc21-e280c511bd86,"North America, Quebec, Hydro-Quebec distribution network",,Electricity,"Québec, HQ distribution network",53.38,-71.78
+1560a2df-f599-3750-9974-8cbda44b4c51,"North America, ReliabilityFirst Corporation",,Electricity,US-RFC,41.82,-83.2
+44193271-0d3b-309d-b869-820f52c4c6db,"North America, SERC Reliability Corporation",,Electricity,US-SERC,34.46,-86.47
+5566919c-eb38-3560-957c-4fddbf8314c7,"North America, Southwest Power Pool",,Electricity,US-SPP,36.18,-97.9
+7e764aa6-b752-3530-855f-0373606d1886,"North America, Texas Regional Entity",,Electricity,US-TRE,31.23,-99.21
+f62a6cfc-7bf3-3556-a8b3-a168accf9875,"North America, Western Electricity Coordinating Council",,Electricity,WECC,46.56,-116.16
+f37ced82-5df8-48c2-a207-1e36dd11a112,"North America, Western Electricity Coordinating Council, US part only",,Electricity,US-WECC,40.71,-113.13
+16096b94-483a-3671-b7a2-16db4118f8df,North American Free Trade Agreement,,Miscellaneous,NAFTA,53.3,-103.84
+07d93568-0b65-31b2-a42f-e4baea021389,North Macedonia,,Country,MK,41.59,21.68
+f9d758b6-d15e-3238-aa0e-e0a3b949fc32,Northern Africa,,Global,UN-NAFRICA,25.13,14.87
+b320e7db-c758-3ba6-8839-81eb83c9d7d7,Northern America,,Global,RNA,58.86,-92.02
+bd6ef2ee-f612-38be-bce0-90c8e64ebaa9,Northern Cyprus,,Miscellaneous,Northern Cyprus,35.27,33.59
+da657f65-6f70-3a48-893f-64cf7be37d09,Northern Europe,,Global,UN-NEUROPE,63.05,13.82
+1f2dfa56-7dcf-3583-bedd-f7aec167fec7,Northern Mariana Islands (the),,Country,MP,16.25,145.59
+7fa3b767-c460-354a-abe4-d49030b349c7,Norway,,Country,NO,64.46,14.08
+61c8d2f5-500d-37c3-a13e-4ed176dcf6d2,Oceania,,Global,UN-OCEANIA,-25.28,136.41
+6aa2b79b-1fc3-384c-b1af-565b51d5e4ad,Oceanic,,Global,OCE,-25.28,136.41
+d58da822-8993-3d8c-8ec4-f40689c2847e,Oman,,Country,OM,20.6,56.09
+cd0acfe0-85ee-30f8-b439-1fb9b8009bed,Pacific Asia,,Global,PAS,12.39,123.83
+655ae040-aec1-37f7-8d79-0580c5ac37ab,Pacific OECD,,Global,PAO,-9.99,148.97
+1cd3c693-132f-3c31-b5b5-e5f4c5eed6bd,Pakistan,,Country,PK,29.94,69.34
+8fe4c114-5128-3c09-8a65-78e6ddbf5eed,Palau,,Country,PW,7.19,134.34
+8812c36a-a5ae-336c-aa77-bf63211d899a,"Palestine, State of",,Country,PS,31.91,35.2
+e529a9ce-a4a7-38eb-9c58-28b13b22844c,Panama,,Country,PA,8.51,-80.12
+235ec523-92b7-3977-939c-f78b62e708d3,Papua New Guinea,,Country,PG,-6.47,145.23
+dfed5bc1-77b8-3ab3-97c5-84e06566adc6,Paraguay,,Country,PY,-23.22,-58.39
+dd07de85-6139-3a7c-b7f8-fcc1752d45e1,Peru,,Country,PE,-9.15,-74.37
+da984e42-a589-3bbd-ac49-6ef0cbadcee2,Philippines (the),,Country,PH,11.76,122.87
+ded0804c-f804-36d2-ae37-953dc2dbc505,Pitcairn,,Country,PN,-24.41,-128.47
+28840420-4e3d-3522-a930-8317344a285d,Poland,,Country,PL,52.12,19.39
+b9b1f592-541c-3b02-bd41-1f6ea05a6ea5,Polynesia,,Global,UN-POLYNESIA,-15.31,-158.36
+fc9fdf08-4e29-3f26-a270-390dc49061a2,Portugal,,Country,PT,39.58,-8.59
+561193d1-987d-3e23-8831-37583bb484ef,"Portugal, Madeira",,Miscellaneous,PT-30,32.74,-16.97
+64e1e1cb-e1ca-3e88-af3a-838a3e7b57d6,Puerto Rico,,Country,PR,18.22,-66.46
+8264ee52-f589-34c0-991a-a94f87aa1aeb,Qatar,,Country,QA,25.31,51.18
+81e54bf8-5993-5b5b-bc50-6978cab0c51f,Rest of Europe,,Unlocated,RoE,0.0,0.0
+f1965a85-7bc2-35d2-afe2-2023aa5ab50d,Rest of World,,Unlocated,RoW,0.0,0.0
+3605c251-087b-3821-ac9b-ca890e07ad9c,Romania,,Country,RO,45.85,24.97
+84c26536-0d12-33e3-8ed0-e7fa435f9a45,Russia (Asia),,Miscellaneous,Russia (Asia),62.73,110.63
+7d199e42-c733-3c12-87e1-ce5672f33ae6,Russia (Europe),,Miscellaneous,Russia (Europe),59.24,45.62
+89484b14-b36a-3d53-a942-6a3d944d2983,Russian Federation (the),,Country,RU,61.98,96.69
+038c0dc8-a958-3fea-97af-047244fb6960,Rwanda,,Country,RW,-1.99,29.91
+12eccbdd-9b32-3181-b134-1f38907cbbb5,Réunion,,Country,RE,-21.11,55.54
+fd18772c-bac1-3277-b20d-cccc1b90efb9,Saint Barthélemy,,Country,BL,17.9,-62.83
+77cbc257-e663-3286-acf6-191754c0c8e3,"Saint Helena, Ascension and Tristan da Cunha",,Country,SH,-24.91,-10.13
+8c7e6965-b416-3689-a88b-313bbe7450f9,Saint Kitts and Nevis,,Country,KN,17.27,-62.69
+196accbc-f32b-3a8e-abef-92e1a37d0fc0,Saint Lucia,,Country,LC,13.9,-60.97
+ea81aa7d-f47d-34c6-b37b-f98fabf3ff82,Saint Martin (French part),,Country,MF,18.07,-63.05
+5109d85d-95fe-3e78-96d9-704e6e5b1279,Saint Pierre and Miquelon,,Country,PM,46.93,-56.3
+c56e5259-4d4e-3e7f-acb2-b96c4637b486,Saint Vincent and the Grenadines,,Country,VC,13.21,-61.2
+742523da-ef59-3b4b-b184-09f46de05d0c,Samoa,,Country,WS,-13.75,-172.16
+ed79acb0-cd3d-3f83-a0c5-3c7798335ef0,San Marino,,Country,SM,43.93,12.44
+627fcdb6-cc9a-3e16-9657-ca6cdef0a6bb,Sao Tome and Principe,,Country,ST,0.44,6.72
+c12e01f2-a13f-3558-be1e-9e4aedb8242d,Saudi Arabia,,Country,SA,24.12,44.53
+d0ea3a63-8908-3b86-a4f9-10b6170de942,Scarborough Reef,,Miscellaneous,Scarborough Reef,15.15,117.75
+afbe94cd-be69-393e-babc-9f1325fc7dff,Senegal,,Country,SN,14.36,-14.47
+3a2d7564-baee-3918-aebc-7b65084aabd1,Serbia,,Country,RS,44.22,20.78
+95cc64dd-2825-39df-93ec-4ad683ecf339,Serbia and Montenegro,,Miscellaneous,CS,44.01,20.56
+cc9dabdf-852c-3698-ae98-b3d1d8b1c324,Serranilla Bank,,Miscellaneous,Serranilla Bank,15.86,-78.63
+d54185b7-1f61-3c30-a396-ac4bc44d3269,Seychelles,,Country,SC,-6.48,52.06
+5f507fb0-b905-3a32-bb57-967d0a3b3b43,Siachen Glacier,,Miscellaneous,Siachen Glacier,35.39,77.17
+54a2bf8c-09ac-367d-b513-aaa1aa7aa0f3,Sierra Leone,,Country,SL,8.56,-11.79
+5dae4296-88af-3c52-9ad8-7ac394192c6d,Singapore,,Country,SG,1.35,103.81
+2c38b9e4-5cec-3b32-8dde-4e3d5b22c648,Sint Maarten (Dutch part),,Country,SX,18.04,-63.07
+41d6ad07-61a5-327a-9e1b-d567041ce9e9,Slovakia,,Country,SK,48.7,19.48
+ac5585d9-8646-3255-a99c-359140537783,Slovenia,,Country,SI,46.11,14.8
+26148d62-1ef7-3844-918a-f182d63976b6,Solomon Islands,,Country,SB,-8.9,159.63
+b807023f-87e6-3b8a-9a92-f79f546ff9cc,Somalia,,Country,SO,4.74,45.7
+4f146d3d-de5e-3896-8bac-17f57c9eaa05,Somaliland,,Miscellaneous,Somaliland,9.73,46.25
+959848ca-10cc-3a60-9a81-8ac11523dc63,South Africa,,Country,ZA,-29.0,25.08
+d34c6aba-144a-3e2d-acb4-0dd5f93ae50e,South America,,Global,UN-SAMERICA,-15.15,-60.78
+1d8d5e91-2302-308b-9e88-c3e77fcad378,South Georgia and the South Sandwich Islands,,Country,GS,-54.67,-35.89
+3691308f-2a4c-3f69-83f2-880d32e29c84,South Sudan,,Country,SS,7.28,30.3
+e832ff92-78c2-3ab2-8f7d-d0ca126994bf,South-Eastern Asia,,Global,UN-SEASIA,7.94,109.91
+326dde39-0b64-3523-b09f-aa0f427066d8,Southern Africa,,Global,UN-SASIA,-25.49,22.52
+a8a64cef-262a-34de-8872-b68b63ab7cd8,Southern Asia,,Global,SAS,27.43,70.79
+fe8f0f22-0c96-348b-86c2-b27e42d27f04,Southern Europe,,Global,UN-SEUROPE,41.48,7.29
+12470fe4-06d4-3017-996e-ab37dd65fc14,Spain,,Country,ES,40.22,-3.65
+e914aa2b-6272-3660-9305-a03124b4d9a8,Spratly Islands,,Miscellaneous,Spratly Islands,10.54,114.92
+d0fa06cd-9333-3c8c-ae35-7ffe5cd1c4e9,Sri Lanka,,Country,LK,7.61,80.7
+748ced3d-d3ad-3822-bb8f-2e73f28ef722,Sub-Sahara Africa,,Global,AFR,-1.23,18.32
+6226f7cb-e59e-39a9-8b5c-ef6f94f966fd,Sudan (the),,Country,SD,15.98,29.93
+e22428cc-f96c-3a96-b4a9-39c209ad1000,Suriname,,Country,SR,4.13,-55.91
+b5bf27b2-555d-344e-bdf2-230080db5a1d,Svalbard and Jan Mayen,,Country,SJ,78.86,18.47
+efad7abb-323e-3d40-9628-4c8a6da076a1,Sweden,,Country,SE,62.77,16.75
+d88fc6ed-f21e-3464-935f-f76288b84103,Switzerland,,Country,CH,46.79,8.21
+1548af1c-94ad-3558-8324-df8f08baf227,Syrian Arab Republic (the),,Country,SY,35.02,38.5
+255a5cac-7685-3722-b4d0-2f04c37be771,Taiwan (Province of China),,Country,TW,23.75,120.94
+456c2e75-fe0f-3a57-bd1c-fd87117e0963,Tajikistan,,Country,TJ,38.52,71.01
+73bb4387-b307-3739-aacb-9cd62ac4049c,"Tanzania, the United Republic of",,Country,TZ,-6.27,34.81
+1fdc0f89-3412-3e55-b0d2-811821b84d3b,Thailand,,Country,TH,15.11,101.0
+313a21d5-badc-3f56-b223-8ebf8c7690f6,Timor-Leste,,Country,TL,-8.82,125.85
+1f0eb098-5870-335e-a2fa-2f68a223b173,Togo,,Country,TG,8.52,0.96
+b6717b91-c759-3cc0-bf30-aa9a784e6390,Tokelau,,Country,TK,-8.96,-171.81
+01b6e203-44b6-3835-85ed-1ddedf20d531,Tonga,,Country,TO,-19.96,-174.84
+accc9105-df53-3311-9407-fd5b41255e23,Trinidad and Tobago,,Country,TT,10.46,-61.25
+aafb96b2-fa88-36be-b07c-4496867bad56,Tunisia,,Country,TN,34.11,9.55
+6a962563-e235-3178-9e66-3e356ac8d9e4,Turkmenistan,,Country,TM,39.11,59.37
+5c4fefda-27cf-384c-b999-be13e6b8608a,Turks and Caicos Islands (the),,Country,TC,21.78,-71.87
+c9a1fdac-6e08-3dd8-9e71-73244f34d7b3,Tuvalu,,Country,TV,-7.75,178.52
+e7d707a2-6e7f-3b6f-b52c-489c60e429b1,Türkiye,,Country,TR,39.06,35.16
+2a0617ac-cf8b-3862-9c43-e2ffeb5b8d5b,Uganda,,Country,UG,1.27,32.36
+5269f4d7-5f5b-375f-8f94-bab2100a5531,Ukraine,,Country,UA,49.16,31.25
+b6bb43df-4525-3928-a105-fb5741bddbea,United Arab Emirates (the),,Country,AE,23.9,54.3
+7885444a-f42e-3b30-8518-c5be17c8850b,United Kingdom of Great Britain and Northern Ireland (the),,Country,GB,54.14,-2.88
+0dd00e33-b6fc-37b8-91eb-e3177217d6c0,United States Minor Outlying Islands (the),,Country,UM,14.01,-97.16
+0b3b97fa-6688-3c56-88ee-4ae80ec0c3c2,United States of America (the),,Country,US,45.68,-112.49
+c385c23d-66c3-3558-989c-db5586384532,"United States of America, Alabama",,Subdivisions,US-AL,32.78,-86.82
+b423ff37-b678-3ea4-9366-ede7b1a7c0c0,"United States of America, Alaska",,Subdivisions,US-AK,64.26,-152.27
+b7745632-fc6d-37f8-85f0-f53c48027b96,"United States of America, Arizona",,Subdivisions,US-AZ,34.29,-111.66
+b54bf461-c111-318c-9f92-a499f34dc05d,"United States of America, Arkansas",,Subdivisions,US-AR,34.9,-92.44
+b775ab58-2693-342d-b496-3265a17b5b32,"United States of America, California",,Subdivisions,US-CA,37.24,-119.6
+12fe7ead-4836-3c05-bbd9-768e2f0fdb66,"United States of America, Colorado",,Subdivisions,US-CO,38.99,-105.54
+e86115dd-61e0-3652-8b8f-79fc693dcf01,"United States of America, Connecticut",,Subdivisions,US-CT,41.62,-72.72
+1ae4da05-1c10-36a3-aadc-da3431d1b677,"United States of America, Delaware",,Subdivisions,US-DE,38.99,-75.5
+efe104ea-d72b-3371-940f-1bb877257ab3,"United States of America, District of Columbia",,Subdivisions,US-DC,38.9,-77.01
+445fe89e-beea-3ff9-8975-167f35b53373,"United States of America, Florida",,Subdivisions,US-FL,28.64,-82.48
+2b701fc6-ef0e-3b9a-9f4d-631863e904f6,"United States of America, Georgia",,Subdivisions,US-GA,32.65,-83.45
+fe2bd352-e70f-3e48-a023-02843b5ac978,"United States of America, Hawaii",,Subdivisions,US-HI,20.25,-156.35
+1f80437b-a9fb-34e0-a052-26a2a7fd5520,"United States of America, Idaho",,Subdivisions,US-ID,44.39,-114.65
+c2521c9e-e466-3960-b789-4046cadadf24,"United States of America, Illinois",,Subdivisions,US-IL,40.12,-89.15
+70f8ca91-42c2-3bae-a4e2-dcc1b8033abe,"United States of America, Indiana",,Subdivisions,US-IN,39.91,-86.28
+fa384517-d567-36e2-9a5a-dd52df663dcf,"United States of America, Iowa",,Subdivisions,US-IA,42.07,-93.49
+d9c55cbc-3e12-3ff1-9370-bdfebddccd5f,"United States of America, Kansas",,Subdivisions,US-KS,38.48,-98.38
+e132e45b-712d-3e2c-af19-c1f1b99c3c91,"United States of America, Kentucky",,Subdivisions,US-KY,37.52,-85.29
+c384a41a-bbea-3bc9-b333-75287ddb64bb,"United States of America, Louisiana",,Subdivisions,US-LA,31.07,-92.01
+4d844119-4127-3a4d-b856-663e8039d21c,"United States of America, Maine",,Subdivisions,US-ME,45.38,-69.23
+86596f8c-55cb-3a71-976f-6a56e871f29b,"United States of America, Maryland",,Subdivisions,US-MD,39.05,-76.79
+85a8277c-cb62-3889-ae66-71d05d9263d3,"United States of America, Massachusetts",,Subdivisions,US-MA,42.25,-71.8
+bb966cd1-e1ba-33fd-8375-56d66970d7df,"United States of America, Michigan",,Subdivisions,US-MI,44.87,-85.73
+7aa1c4da-339b-3230-8838-2de0f6a6581a,"United States of America, Minnesota",,Subdivisions,US-MN,46.34,-94.19
+0ee63262-59b9-3da8-8cf7-5f42828ffa7b,"United States of America, Mississippi",,Subdivisions,US-MS,32.76,-89.67
+cdc9423a-0890-3494-b717-51263425bcf6,"United States of America, Missouri",,Subdivisions,US-MO,38.37,-92.48
+a220b227-87c9-368d-8bfe-5ff357517419,"United States of America, Montana",,Subdivisions,US-MT,47.03,-109.63
+669eb22e-cf87-3b59-a553-06880eed6a5a,"United States of America, Nebraska",,Subdivisions,US-NE,41.52,-99.8
+f9eab7a5-2fbd-36f4-b88f-438ba1a8da94,"United States of America, Nevada",,Subdivisions,US-NV,39.35,-116.65
+ca2b1447-f5e7-3554-b244-ee56ce0e92ff,"United States of America, New Hampshire",,Subdivisions,US-NH,43.68,-71.57
+52c1fc37-d9e9-33a1-aaea-c2bc601b0364,"United States of America, New Jersey",,Subdivisions,US-NJ,40.19,-74.66
+560e664b-9150-3314-b530-1eaa6af5b067,"United States of America, New Mexico",,Subdivisions,US-NM,34.42,-106.11
+0efe3dd6-681d-3dd2-8970-52bea5982168,"United States of America, New York",,Subdivisions,US-NY,42.99,-75.68
+cf1fe73c-b3b8-3e6a-a362-a24cc00edca8,"United States of America, North Carolina",,Subdivisions,US-NC,35.54,-79.39
+7d5a6438-e66c-37d7-b069-9f6cbb9efb22,"United States of America, North Dakota",,Subdivisions,US-ND,47.44,-100.47
+8f530ffb-71ad-30e5-8e27-ea335b94166f,"United States of America, Ohio",,Subdivisions,US-OH,40.41,-82.71
+9704b0fb-3771-33d7-a07d-a7d6e1a431a2,"United States of America, Oklahoma",,Subdivisions,US-OK,35.58,-97.51
+7fb70584-7e67-3d35-9d3a-16a62784d3a3,"United States of America, Oregon",,Subdivisions,US-OR,43.94,-120.54
+22b8b398-1b5b-3955-a162-614bb67b5927,"United States of America, Pennsylvania",,Subdivisions,US-PA,40.89,-77.84
+869d2f4d-09bf-3b85-b19d-3cd046b07ac5,"United States of America, Rhode Island",,Subdivisions,US-RI,41.67,-71.55
+58a2cc24-3eaf-3596-988e-742e109b66fd,"United States of America, South Carolina",,Subdivisions,US-SC,33.91,-80.89
+112e6937-5e63-32a1-ba68-730cbd933c75,"United States of America, South Dakota",,Subdivisions,US-SD,44.43,-100.23
+1be0b149-5590-34c3-bee8-fdb3255c95f4,"United States of America, Tennessee",,Subdivisions,US-TN,35.84,-86.34
+f767f1ae-d126-3766-846d-62fa2f6f927f,"United States of America, Texas",,Subdivisions,US-TX,31.5,-99.35
+10334e82-fe92-33bf-9d45-2decb730b1c2,"United States of America, Utah",,Subdivisions,US-UT,39.32,-111.67
+3b7e10ba-fd35-381d-8ff5-8811c0f6bf32,"United States of America, Vermont",,Subdivisions,US-VT,44.07,-72.66
+4ec8c4f4-fd4d-3a38-80a5-7446f9420f11,"United States of America, Virginia",,Subdivisions,US-VA,37.51,-78.84
+9ef574c2-cd1a-3866-b782-5e74b2c6cfcb,"United States of America, Washington",,Subdivisions,US-WA,47.38,-120.43
+a8ce62fb-3610-311c-8af0-a8bf4942f5a0,"United States of America, West Virginia",,Subdivisions,US-WV,38.64,-80.61
+38af12ff-e146-3293-a429-6ddf9c28b806,"United States of America, Wisconsin",,Subdivisions,US-WI,44.64,-89.73
+373367f9-6d69-3917-ac7a-b9b523b4f30f,"United States of America, Wyoming",,Subdivisions,US-WY,42.99,-107.55
+1b23f8a4-c97c-355f-b57e-c2aae921f03d,Uruguay,,Country,UY,-32.79,-56.01
+aae773f6-9106-3fd9-95d0-c38764e6dccd,US Naval Base Guantanamo Bay,,Miscellaneous,US Naval Base Guantanamo Bay,19.92,-75.15
+8b3274b7-55aa-3339-82f5-7fb557e25923,Uzbekistan,,Country,UZ,41.75,63.13
+0730b75e-96c0-353b-9b19-6be7ff4fa194,Vanuatu,,Country,VU,-16.2,167.7
+eabb18f0-a40c-3b35-9237-0c9e1bc1d61e,Venezuela (Bolivarian Republic of),,Country,VE,7.12,-66.16
+5e9c52c6-d618-381e-bd9d-62a294c4979c,Viet Nam,,Country,VN,16.64,106.3
+1815235d-384d-3912-9466-8c73298f1e52,Virgin Islands (British),,Country,VG,18.5,-64.5
+35b36b28-916d-38b3-8abd-df832e286126,Virgin Islands (U.S.),,Country,VI,17.98,-64.79
+c1b291cb-8522-336e-8217-31b509c9fcdd,Wallis and Futuna,,Country,WF,-13.84,-177.23
+fb033b5d-d7d0-37f5-a147-c0bfed75d56c,Western Africa,,Global,UN-WAFRICA,14.74,-1.18
+02cb9a5a-488d-3ea0-84d9-3ae7b315e386,Western Asia,,Global,UN-WASIA,29.57,46.32
+27ec30d1-c271-32b7-8cdf-d39530307275,Western Europe,,Global,WEU,48.53,6.47
+28c494da-87ff-3996-9927-ac34ba30adbe,Western Sahara,,Country,EH,24.23,-12.21
+00c66f1a-036b-38f9-8b70-9cb8d925d3d9,Yemen,,Country,YE,15.9,47.59
+d9c29677-6530-3ff5-92a5-ab979ed1f7a0,Zambia,,Country,ZM,-13.46,27.77
+a1555463-c361-3703-aa27-4a8b44e29192,Zimbabwe,,Country,ZW,-19.0,29.85
+9cea1e24-73aa-3499-95fa-34faac95b3e7,Åland Islands,,Country,AX,60.11,20.15

--- a/refdata/unit_groups.csv
+++ b/refdata/unit_groups.csv
@@ -1,28 +1,21 @@
 ID,Name,Description,Category,Default flow property,Reference unit
 93a60a57-a3c8-18da-a746-0800200c9a66,Units of area,,Technical unit groups,Area,m2
-93a60a57-a3c8-20da-a746-0800200c9a66,Units of area*time,,Technical unit groups,Area*time,m2*a
-da299c4d-1741-4da8-9fbd-5ccfb5e1d688,Units of currency,,Economic unit groups,"Market value, bulk prices",EUR 2000
+93a60a57-a3c8-20da-a746-0800200c9a66,Units of area*time,,Technical unit groups,Area*Time,m2*a
+da299c4d-1741-4da8-9fbd-5ccfb5e1d688,Units of currency,,Economic unit groups,Market value,USD
 93a60a57-a3c8-11da-a746-0800200c9a66,Units of energy,,Technical unit groups,Energy,MJ
-876adcd3-29e6-44e2-acdd-11be304ae654,Units of energy/area*time,,Technical unit groups,Energy/area*time,kWh/m2*d
-258d6abd-14f2-4484-956c-c88e8f6fd8ed,Units of energy/mass*time,,Technical unit groups,Energy/mass*time,MJ/kg*d
-9e5a91be-b3d1-4268-8e7d-e5e93f6a75d4,Units of groundwater replenishment (transf.),,Technical unit groups,Groundwater Replenishment (Transf.),(mm*m2)/a
-5beb6eed-33a9-47b8-9ede-1dfe8f679159,Units of items,,Technical unit groups,Number of items,Item(s)
-5454b231-270e-45e6-89b2-7f4f3e482245,Units of items*length,,Technical unit groups,Items*Length,Items*km
 838aaa22-0117-11db-92e3-0800200c9a66,Units of length,,Technical unit groups,Length,m
-36932b14-ba61-417b-a80c-eb9935d193f1,Units of length*area,,Technical unit groups,Groundwater Replenishment (Occ.),mm*m2
-f2275057-f8be-4db9-bb78-5dfc276967a0,Units of length*area/time,,Technical unit groups,Mechanical Filtration (Transf.),cm*m2/d
-326eb58b-e5b3-4cea-b45a-2398c25109f8,Units of length*time,,Technical unit groups,Length*time,m*a
+326eb58b-e5b3-4cea-b45a-2398c25109f8,Units of length*time,,Technical unit groups,Length*Time,km*a
 93a60a57-a4c8-11da-a746-0800200c9a66,Units of mass,,Technical unit groups,Mass,kg
-838aaa21-0117-11db-92e3-0800200c9a66,Units of mass*length,,Technical unit groups,Goods transport (mass*distance),t*km
-59f191d6-5dd3-4553-af88-1a32accfe308,Units of mass*time,,Technical unit groups,Mass*time,kg*a
-c28831de-8759-43da-98bd-05617cb1722d,Units of mass/time,,Technical unit groups,Biotic Production (Transf.),kg/a
-59f6a0a2-731f-41c3-86df-d383dc673dfe,Units of mechanical filtration (occ.),,Technical unit groups,Mechanical Filtration (Occ.),cm*m3
-a6941776-ee4b-40fe-9a05-e19faac45240,Units of mole*area*time/mass,,Technical unit groups,Physicochemical Filtration (Occ.),(cmol*m2*a)/kg
-3dbb60e1-edde-49f7-b28d-f34b4af727b3,Units of mole*area/mass,,Technical unit groups,Physicochemical Filtration (Transf.),(cmol*m2)/kg
-11d161f0-37e3-4d49-bf7a-ff4f31a9e5c7,Units of person transport,,Technical unit groups,Person transport,p*km
+838aaa21-0117-11db-92e3-0800200c9a66,Units of mass*length,,Technical unit groups,Mass transport,t*km
+59f191d6-5dd3-4553-af88-1a32accfe308,Units of mass*time,,Technical unit groups,Mass*Time,kg*d
+f170abd3-f010-45f4-8e7c-9871a5c0421b,Units of mole,,Technical unit groups,Mole,mol
+5beb6eed-33a9-47b8-9ede-1dfe8f679159,Units of number,,Technical unit groups,Number,Item(s)
+5454b231-270e-45e6-89b2-7f4f3e482245,Units of number*length,,Technical unit groups,Item transport,Items*km
+11d161f0-37e3-4d49-bf7a-ff4f31a9e5c7,Units of person*length,,Technical unit groups,Person transport,p*km
+4a4f6060-85a7-3ad8-961b-00844a2dfa96,Units of person*time,,Technical unit groups,Guest night,guest night
+d2779afe-bb00-48fe-9533-63cd0b3048dc,Units of power,,Technical unit groups,Power,W
 93a60a57-a3c8-16da-a746-0800200c9a66,Units of radioactivity,,Technical unit groups,Radioactivity,kBq
-af638906-3ec7-4314-8de7-f76039f2dd01,Units of time,,Technical unit groups,Duration,d
-af16ae7e-3e04-408a-b8ae-5b3666dbe7f9,Units of vehicle transport,,Technical unit groups,Vehicle transport,v*km
+af638906-3ec7-4314-8de7-f76039f2dd01,Units of time,,Technical unit groups,Time,h
 93a60a57-a3c8-12da-a746-0800200c9a66,Units of volume,,Technical unit groups,Volume,m3
-ff8ed45d-bbfb-4531-8c7b-9b95e52bd41d,Units of volume*length,,Technical unit groups,Volume*Length,m3*km
-93a60a57-a3c8-23da-a746-0800200c9a66,Units of volume*time,,Technical unit groups,Volume*time,m3*a
+ff8ed45d-bbfb-4531-8c7b-9b95e52bd41d,Units of volume*length,,Technical unit groups,Volume transport,m3*km
+93a60a57-a3c8-23da-a746-0800200c9a66,Units of volume*time,,Technical unit groups,Volume*Time,m3*a

--- a/refdata/units.csv
+++ b/refdata/units.csv
@@ -1,191 +1,178 @@
 ID,Name,Description,Conversion factor,Synonyms,Unit group
-691ae73c-3fc1-4157-85d0-2659bdc2380a,(cmol*m2)/kg,Centimole times square metre per kilogram,1.0,,Units of mole*area/mass
-2e16ca4a-9f65-472f-b4cb-274050aaf328,(cmol*m2*a)/kg,Centimole times square metre times year per kilogram,1.0,,Units of mole*area*time/mass
-95e8feec-abc7-4eb0-bf39-2a6d411cba8d,(mm*m2)/a,Millimetre times square metre per year,1.0,,Units of groundwater replenishment (transf.)
-14ed0060-9198-48c1-b458-7fa4075c9811,AUD 2000,Australian dollar,0.63,,Units of currency
-ac324d87-9961-463a-81a1-099bb0f7d89b,Bq,"Bequerel, 1 event per second",0.001,,Units of radioactivity
-18b04307-98b7-4d9e-82ee-f11d1b9f0d28,CAD 2000,Canadian dollar,0.73,,Units of currency
-8632c804-eed7-4a57-91e6-1798289c49e3,CHF 2000,Swiss franc,0.64,,Units of currency
-d0c791b3-d989-4d90-906c-d01006e45ce0,CHF 2005,Swiss franc,1.12,,Units of currency
-fd100082-4cdf-4932-9282-6bb7d7091bd4,CZK 2000,Czech koruna,0.02,,Units of currency
-ef6d9358-a156-4c73-b678-320ddee7d2eb,Ci,Curie,3.7E7,,Units of radioactivity
-2f3cc326-da25-4086-b06d-3a7ef914aef6,DKK 2000,Danish krone,0.13,,Units of currency
-3bd6c6c3-bb61-46f3-b19a-c87ac5502bb7,Dozen(s),Dozen(s) of items,12.0,,Units of items
-0866bd06-77b3-41a2-8157-6d96ffb5666b,EEK 2000,Estonian kroon,0.06,,Units of currency
-a55b7fe7-fa09-47ef-be62-e07b8e6f4351,EUR 2000,Euro,1.0,,Units of currency
-e0c570ff-d195-4646-b15d-b8de687d10a8,EUR 2003,Euro 2003,1.25,,Units of currency
-ae63f1fd-3679-443a-ad06-8d03e867351e,GBP 2000,Pound sterling,1.65,,Units of currency
+8ee3bcbf-9e65-4f59-9b0b-40b504cbe345,ac,Acre (US Survey),4046.872,acre (US);acre,Units of area
+e114cd83-3e7f-4466-8028-761c0469f7c7,are,Are,100.0,,Units of area
+588613d5-6c8c-4ab6-8c69-ec5e20ef7881,cm2,Square centimetre,1.0E-4,,Units of area
+dc4bb818-ab06-4f65-ade9-a69a3ca116fd,dm2,Square decimetre,0.01,,Units of area
+c66d26f1-7946-4027-85f0-ac79222a59f1,ft2,Square international foot,0.09290304,ft²;sq.ft,Units of area
+debee4d9-bc47-4e35-8624-4957ecb75386,ha,Hectare,10000.0,,Units of area
+cd277914-c68c-4be4-b7cf-cdf17a6e7f48,in2,Square inch,6.4516E-4,sq.in,Units of area
+b9a011a0-c9bf-459b-b105-2623d1b61ddf,km2,Square kilometre,1000000.0,km²,Units of area
+3ce61faa-5716-41c1-aef6-b5920054acc9,m2,Square metre,1.0,m²,Units of area
+20ce5f57-69b1-438b-a8e8-23089854d058,mi2,Square international mile,2589988.11,mi²;sq.mi,Units of area
+0992b8e3-489a-46ea-8d71-1bf951ece5d0,mm2,Square millimetre,1.0E-6,,Units of area
+4689d28c-29f6-4f0a-ad03-0276f7070edd,nmi2,Square nautical mile,3429904.0,,Units of area
+6c4b1e4a-bf45-4385-a60c-12cc48ecbab5,yd2,Square international yard,0.836127,sq.yd,Units of area
+0d255e00-8aa1-434e-b6cd-43991a87d3fa,cm2a,Square centimetre times year,1.0E-4,,Units of area*time
+efbbab8b-eb92-4e39-bd5f-99951ffda6c3,ft2*a,Square international foot times year,0.090304,ft²*a;ft²a;ft2a,Units of area*time
+4866ec7b-6218-4783-87b4-cbd107280a85,ha*a,Hectare times year,10000.0,ha a,Units of area*time
+c8166ae2-b592-4eb9-b365-e384c8b79f3c,km2*a,Square kilometre times year,999999.9999999999,km²*a;km2a;km²a,Units of area*time
+c7266b67-4ea2-457f-b391-9b94e26e195a,m2*a,Square metre times year,1.0,m²*a;m2a;m²a;m2*year,Units of area*time
+00d8370e-2bf1-4f3b-81bb-f8f147e84819,m2*d,Square metre times day,0.00273972602,,Units of area*time
+1c43f336-c84b-4f42-bbf7-b1b6f89e121a,mi2*a,Square international mile times year,2589988.11,mi²*a;mi2a;mi²a,Units of area*time
+b396b97c-29ab-409a-b6fa-2285589041bd,mm2a,Square millimetre times year,1.0E-6,,Units of area*time
+f5b2fb9d-ccc4-4b71-b5cc-59618fc0e170,AUD,,0.699,,Units of currency
+cfa81ea3-c1c9-4319-af9f-17d069603659,CAD,,0.76,,Units of currency
+2c42095d-580c-40c4-a9a3-5d9eb78ef285,CHF,,1.06,,Units of currency
+8481fea2-c670-4c7f-baa7-c81d0656c80f,CNY,,0.147,,Units of currency
+5f12a853-06a8-4277-833c-bca877cb29ee,EUR,,1.12,,Units of currency
+e24ca38c-cb14-44d3-85e7-d801c97fdf34,GBP,,1.28,,Units of currency
+ac90ae60-f133-45a9-8bd3-b0cca36465c7,HKD,,0.128,,Units of currency
+d0f654ec-8451-4c47-bcc7-167cff07b31f,JPY,,0.00835,,Units of currency
+755b34c3-4525-449b-b576-7269c0f633db,SEK,,0.104,,Units of currency
+bf5acdd4-f257-466f-8a45-721a25dd1820,SGD,,0.733,,Units of currency
+a24e8745-d867-449e-a6a2-3fdbde687125,USD,,1.0,,Units of currency
+673a9bd3-6385-46a7-b552-b9f39b361ca3,ZAR,,0.062,,Units of currency
+55244053-94ba-404e-9172-cb279d905e00,btu,British thermal unit (International Table),0.0010551,,Units of energy
 01e58eb9-0aba-4c76-ba0c-03f6f3be1353,GJ,Gigajoule,1000.0,,Units of energy
-fb4258af-95b2-4359-af03-9687178df527,HUF 2000,Hungarian forint,0.0038,,Units of currency
-28bb8ff6-79d1-4f97-b7c4-7fa3dd05bec8,ISK 2000,Iceland krona,0.01,,Units of currency
-cff8f1bf-bda0-4fc1-b14c-537d8861dcce,Imp.min.,Minim,5.91938802E-8,,Units of volume
-6dabe201-aaac-4509-92f0-d00c26cb72ab,Item(s),Number of items,1.0,unit;LU;pig place;p,Units of items
-2abb86b6-e71b-4de5-a766-a20e80e59b6d,Items*km,Items times kilometre,1.0,,Units of items*length
-ce39138f-55f8-47bc-b55a-66027fc836d9,Items*mi,Items times international mile,1.609344,,Units of items*length
-9bf0166c-fa76-47d0-95af-054ea9125f2c,Items*nmi,Items times nautical mile,1.852,,Units of items*length
 469d61f1-3bc4-4841-8adf-873825c1bc11,J,Joule,1.0E-6,,Units of energy
-6c277db7-2784-4296-83bf-15c04a9d59b2,JPY 2000,Japanese yen,0.01,Yen2000,Units of currency
-d246fd48-c363-4f0e-ab01-641325dd89eb,KRW 2000,South Korean won,9.5E-4,,Units of currency
-dce13106-087c-4fea-bfaa-def214e3cecb,LTL 2000,Lithuanian litas,0.27,,Units of currency
-007f0ce1-4a0b-4bb2-8f7c-1b2a0e6ef6b2,LVL 2000,Latvian lats,1.78,,Units of currency
-b9948675-d7f6-4f0b-afa0-aa320718bb98,M$ 2000,Mega US dollar 2000,1100000.0,,Units of currency
+010f811e-3cc2-4b14-a901-337da9b3e49c,kcal,Kilocalorie (International Table),0.004184,,Units of energy
+f4119718-2d50-47fe-9154-cab6fd2d30eb,kJ,Kilojoule,0.001,,Units of energy
+86ad2244-1f0e-4912-af53-7865283103e4,kWh,Kilowatt times hour,3.6,,Units of energy
 52765a6c-3896-43c2-b2f4-c679acf13efe,MJ,Megajoule,1.0,,Units of energy
-94dcd768-ea3e-47da-ba1b-11fea4b5f4cc,MJ/kg*d,Megajoule per kilogram times day,1.0,,Units of energy/mass*time
 92e3bd49-8ed5-4885-9db6-fc88c7afcfcb,MWh,Megawatt times hour,3600.0,,Units of energy
-d022bf34-1162-4579-90ab-dcca9620ce54,Mg,Megagram = 1 metric tonne,1000.0,,Units of mass
-9dd23b40-4394-4f9a-9572-5f2ee9643864,Mt,Megatonne,1.0E9,Mtn,Units of mass
-97ee3997-137d-4d96-80bf-c4f106c743c4,NOK 2000,Norwegian krone,0.12,,Units of currency
-4669b8ce-894d-405a-95d1-3211accaa739,Nm3,Normal cubic metres,1.0,Nm³,Units of volume
-ff1a332f-967c-4084-8b01-8d3ca81b3121,PJ,PetaJoules,1.0E9,,Units of energy
-a45722ee-fc30-4bb1-aa95-5c8fb56c6bfb,Rutherford,Rutherford,1000.0,,Units of radioactivity
-594fb96f-0d06-4053-9263-826fcd4d0046,SEK 2000,Swedish krona,0.12,,Units of currency
+ff1a332f-967c-4084-8b01-8d3ca81b3121,PJ,Petajoule,1.0E9,,Units of energy
 787f2ac9-7bcd-4a91-9fab-55bfe414138f,TCE,Tonne coal equivalent,29307.6,,Units of energy
 57c492e7-d94b-4fcc-98df-cdc4163b754c,TJ,Terajoule,1000000.0,,Units of energy
 425aff51-b7e5-4561-aa5a-562ec103a79e,TOE,Tonne oil equivalent,41868.0,,Units of energy
-2d64c7e0-1167-42ec-9988-c441c261a35c,US fl oz,US customary fluid ounce,2.95735295625E-5,,Units of volume
-3f838c0d-bf6c-49f1-a465-d256ab0d13eb,USD 2000,US dollar,1.1,$,Units of currency
-930e411f-542b-4f66-8e83-b04c303a9780,USD 2002,US dollar 2002,1.29,$,Units of currency
 fc3604f7-aa93-4aa3-8ae9-8f822874da5f,Wh,Watt times hour,0.0036,,Units of energy
-71326000-165d-41fb-aea9-1bfbd9d7fc6c,ZAR 2000,South African rand,0.15,,Units of currency
-9a87f840-752d-4863-b911-533f92ee5073,a,Year (rounded),365.0,year;yr,Units of time
-8ee3bcbf-9e65-4f59-9b0b-40b504cbe345,ac,Acre (US survey),4046.872,acre (US);acre,Units of area
-e114cd83-3e7f-4466-8028-761c0469f7c7,are,Are,100.0,,Units of area
-91995a9e-3cb4-4fc9-a93b-8c618ff9b948,bbl,Barrel (petroleum),0.158987294928,,Units of volume
-9bc2cfb2-fb43-42e6-9783-6c7479c78cce,bl (Imp),Barrel (Imperial),0.158987294928,,Units of volume
-a681e9e5-6304-45f0-a5f4-df413eee0724,bl (US beer),Barrel (US beer),0.117,,Units of volume
-1c4169d1-4fee-40e3-9868-953ee15e26ae,bl (US dry),Barrel (US dry),0.1156,,Units of volume
-89121cea-0d98-4466-9b0f-e33e448db7ec,bl (US fl),Barrel (US non-beer fluid),0.119,,Units of volume
-90888d8d-3d57-497f-a3fa-12aefd2bc774,bsh (Imp),Imperial bushel,0.03636872,,Units of volume
-5ec65531-6bb4-4990-a687-44e9ab8f3529,bsh (US),US bushel,0.03,,Units of volume
-55244053-94ba-404e-9172-cb279d905e00,btu,British thermal unit (International table),0.0010551,,Units of energy
-218bf752-ec01-43a9-b87c-0e733374fffd,cg,Centigram,1.0E-5,,Units of mass
 127eddde-af81-4d0d-88f3-123c0b65d971,ch,Chain,20.1168,,Units of length
-ac4057f9-ec4a-4b31-9d3b-ff96969e50ff,cl,Centilitre,1.0E-5,cL,Units of volume
 d018183e-ea8c-4a41-a303-627c9b9b173d,cm,Centimetre,0.01,,Units of length
-aa14a795-2239-496a-81b0-ad7cb8bbe0d2,cm*m2/d,Centimetre times square metre per day,1.0,,Units of length*area/time
-2f1b55fb-a432-447a-a0f5-9b02bf649724,cm*m3,Centimetre times cubic metre,1.0,,Units of mechanical filtration (occ.)
-588613d5-6c8c-4ab6-8c69-ec5e20ef7881,cm2,Square centimetre,1.0E-4,,Units of area
-0d255e00-8aa1-434e-b6cd-43991a87d3fa,cm2a,Square centimetres * year,1.0E-4,,Units of area*time
-46930fb7-8660-42a4-983e-19cf53da740b,cm3,Cubic centimetres,1.0E-6,,Units of volume
-9e6a97bb-e0cf-4e4a-9f3a-37067740b421,cm3*a,Cubic centimetres * year,1.0E-6,cm3y,Units of volume*time
-ae5cced9-f9f1-4719-bd37-837b36013d96,ct,Carat (metric),2.0E-4,carat,Units of mass
-07973a41-56b3-4e1b-a208-fd75a09fbd4b,cu ft,Cubic feet,0.0283168,cuft,Units of volume
-2a0b9356-a2dd-444f-991e-ce66cd174c9e,cwt,Short hundredweight,45.359237,,Units of mass
-11074cfd-08a4-449b-adad-18ce24a1b275,d,Day,1.0,day,Units of time
-90d59045-3565-4c5a-bb27-ebc365aacbd0,dag,Decagram,0.01,,Units of mass
-2d895297-8e96-45f1-b256-a6d4ccd4bbc4,dal,Decalitre,0.01,daL,Units of volume
 9428cdb2-e08e-46f9-a9aa-85cc11416b5f,dam,Decametre,10.0,,Units of length
-2ac22d0d-9e02-4459-9402-923490e4e1b4,dg,Decigram,1.0E-4,,Units of mass
-626c92d5-dcc2-40d4-b28b-4a4f82123740,dl,Decilitre,1.0E-4,dL,Units of volume
 35b9b720-0518-4476-941e-282d9654161a,dm,Decimetre,0.1,,Units of length
-dc4bb818-ab06-4f65-ade9-a69a3ca116fd,dm2,Square decimetres,0.01,,Units of area
-2ea37335-f10b-4fcc-b4a9-0a742d651fa2,dm3,Cubic decimeter,0.001,,Units of volume
-56f42b51-bb05-4dcd-a069-0693f167304c,dr (Av),Dram (Avoirdupois),0.0017718451953125,,Units of mass
-72ef94e2-bf0c-4e85-a74c-f3b5ed1bd73e,dr (Fl),Dram (Fluid),3.6966911953125E-6,,Units of volume
-a3350a8a-5cb0-440d-9752-8afe8c08c455,dwt,Pennyweight,0.001555174,,Units of mass
-806c64aa-8609-4ff6-a033-6714a3348f24,fl oz (Imp),Fluid ounce (Imperial),2.841E-5,,Units of volume
-f7905d3f-904d-4fdb-829e-54a72fb4c98e,ft,Foot (international),0.3048,,Units of length
-c66d26f1-7946-4027-85f0-ac79222a59f1,ft2,British square feet,0.09290304,ft²;sq.ft,Units of area
-efbbab8b-eb92-4e39-bd5f-99951ffda6c3,ft2*a,British square feet times year,0.090304,ft²*a;ft²a;ft2a,Units of area*time
+f7905d3f-904d-4fdb-829e-54a72fb4c98e,ft,International foot,0.3048,,Units of length
 31ace5ab-d905-46ef-b958-caa2e65d6424,ftm,Fathom,1.8288,,Units of length
 1135c9c8-05e9-4831-9eb2-e1c4759f218d,fur,Furlong,201.168,,Units of length
-e1317ffc-7f83-4a85-bc65-4fb229a25cf8,g,Gram,0.001,,Units of mass
-2fdc0039-6c5e-489a-af77-b225684fa337,g*a,Gram times year,0.001,,Units of mass*time
-8aa31dda-e324-469c-a29d-56476584f5ca,gal (Imp),"Gallon (Imperial); used in UK, United Arab Emirates for fuels",0.00454609,,Units of volume
-c530708d-be50-4207-b536-23d0857210bf,gal (US dry),Gallon (US dry),0.00440488377086,,Units of volume
-431df202-da83-4baa-b576-5d17f59f0c8a,gal (US fl),Gallon (US fluid); used in US e.g. for fuel,0.003785411784,,Units of volume
-62eb6f51-0574-4489-ae1a-1bd806f6c2ac,gal (US liq),Gallon (US liquid),0.003785411784,gal*,Units of volume
-078c7a18-a743-491d-87c2-530454661ef1,gill,Gill,1.18294E-4,,Units of volume
-78af80e7-ede4-4a65-b04d-97d9ce4f39d3,gr,Grain,6.479891E-5,,Units of mass
-227a54d9-44e7-468c-b8bb-f2dd1ae68c7a,h,Hour,0.041666666666666664,hr,Units of time
-debee4d9-bc47-4e35-8624-4957ecb75386,ha,Hectare,10000.0,,Units of area
-4866ec7b-6218-4783-87b4-cbd107280a85,ha*a,Hectare times year,10000.0,ha a,Units of area*time
-86dfd16d-d1d8-4b71-88af-0e1126425c77,hg,Hectogram,0.1,,Units of mass
-2a39ac84-f3f0-4296-8907-ffc2f41aebfc,hh,Hand,0.1016,,Units of length
-e24e5e7b-6c5c-4847-969d-7772ed5df017,hl,Hectolitre,0.1,hL,Units of volume
+2a39ac84-f3f0-4296-8907-ffc2f41aebfc,hh,Hand,0.10159999999999998,,Units of length
 0a025f54-0114-4548-a564-d91aa8eb8174,hm,Hectometre,100.0,,Units of length
-030e99e1-2237-483c-8447-8b3a256d8b0d,in,Inch,0.0254,inch,Units of length
-cd277914-c68c-4be4-b7cf-cdf17a6e7f48,in2,Square inches,6.4516E-4,sq.in,Units of area
-6a7531d3-3b83-4dda-8b18-4e3528491f9e,in3,Cubic inches,1.63871E-5,cu.in,Units of volume
-e9773595-284e-46dd-9671-5fc9ff406833,kBq,"Kilo-Bequerel, 1000 events per second",1.0,,Units of radioactivity
-f4119718-2d50-47fe-9154-cab6fd2d30eb,kJ,Kilojoule,0.001,,Units of energy
-86ad2244-1f0e-4912-af53-7865283103e4,kWh,Kilowatt times hour,3.6,,Units of energy
-aff60d84-007c-4f30-bfda-3853760f6954,kWh/m2*d,Kilowatthour per square metre times day,1.0,kWh/m2d;kWh/m²d,Units of energy/area*time
-010f811e-3cc2-4b14-a901-337da9b3e49c,kcal,Kilocalorie (International table),0.004184,,Units of energy
-20aadc24-a391-41cf-b340-3e4529f44bde,kg,Kilogram,1.0,,Units of mass
-95dd50e9-c184-4412-9afc-9764b1ffcf8f,kg SWU,Kilogram SWU,1.0,,Units of mass
-b2ad404c-3e4f-4a7a-a604-46fb36654823,kg*a,Kilogram times year,1.0,kgy,Units of mass*time
-ab01fe47-d2c0-4308-adb1-e32df38d5a50,kg*d,Kilogram times day (1 year = 365 days),0.00273972,,Units of mass*time
-a40229e6-7275-42e3-a304-23d590044770,kg*km,Kilogram-kilometre,0.001,kgkm,Units of mass*length
-94b84332-8f2d-4592-b2a0-e19da33a69e9,kg/a,Kilogram per year,1.0,,Units of mass/time
+030e99e1-2237-483c-8447-8b3a256d8b0d,in,Inch,0.025399999999999995,inch,Units of length
 715ca68e-0ac5-4c4b-b557-fdc36623be88,km,Kilometre,1000.0,,Units of length
-8cbb4edb-d76c-41f7-8b30-cc789217c954,km*a,Kilometres * year,1000.0,kmy,Units of length*time
-b9a011a0-c9bf-459b-b105-2623d1b61ddf,km2,Square kilometre,1000000.0,km²,Units of area
-c8166ae2-b592-4eb9-b365-e384c8b79f3c,km2*a,Square kilometre times year,1000000.0,km²*a;km2a;km²a,Units of area*time
+3d314eab-ef11-4ff3-a35e-9bc5cd858694,m,Metre,1.0,,Units of length
+4a51d52b-f94f-4168-a38c-c612f14b8a2d,mi,International mile,1609.344,mile,Units of length
+cc44768b-c0ce-4bc9-804a-c59b67d22e39,mm,Millimetre,0.001,,Units of length
+1f112940-6c27-4c75-828a-46d548d71cff,nmi,Nautical mile,1852.0,,Units of length
+9003179a-bf17-4e89-8fd7-a0c1c91ac189,u,Micron,9.999999999999997E-7,µm;um,Units of length
+a16960ba-31e2-4fe9-82fe-219013f4708f,yd,International yard,0.9144,yard,Units of length
+8cbb4edb-d76c-41f7-8b30-cc789217c954,km*a,Kilometre times year,1.0,kmy;km*year,Units of length*time
+f7fe0af2-e764-4984-bb9f-2cbff6cd2f18,m*a,Metre times year,0.001,ma;my,Units of length*time
+7d082bce-60f5-4588-86bb-56e0dff1c8a8,mi*a,International mile times year,1.609344,miy,Units of length*time
+218bf752-ec01-43a9-b87c-0e733374fffd,cg,Centigram,1.0E-5,,Units of mass
+ae5cced9-f9f1-4719-bd37-837b36013d96,ct,Matric carat,2.0E-4,carat,Units of mass
+2a0b9356-a2dd-444f-991e-ce66cd174c9e,cwt,Short hundredweight,45.359237,,Units of mass
+90d59045-3565-4c5a-bb27-ebc365aacbd0,dag,Decagram,0.01,,Units of mass
+2ac22d0d-9e02-4459-9402-923490e4e1b4,dg,Decigram,1.0E-4,,Units of mass
+56f42b51-bb05-4dcd-a069-0693f167304c,dr (Av),Dram (Avoirdupois),0.0017718451953125,,Units of mass
+a3350a8a-5cb0-440d-9752-8afe8c08c455,dwt,Pennyweight,0.001555174,,Units of mass
+e1317ffc-7f83-4a85-bc65-4fb229a25cf8,g,Gram,0.001,,Units of mass
+78af80e7-ede4-4a65-b04d-97d9ce4f39d3,grain,Grain,6.479891E-5,gr,Units of mass
+86dfd16d-d1d8-4b71-88af-0e1126425c77,hg,Hectogram,0.1,,Units of mass
+20aadc24-a391-41cf-b340-3e4529f44bde,kg,Kilogram,1.0,,Units of mass
+95dd50e9-c184-4412-9afc-9764b1ffcf8f,kg SWU,Kilogram (Separative Work Unit),1.0,,Units of mass
 e720c842-19f5-4a38-8573-78dd13719f5b,kt,Kilotonne,1000000.0,,Units of mass
-097768e6-0763-4126-a253-e323cafdf77e,kt*km,Kilotonne * kilometre,1000.0,ktkm,Units of mass*length
+0300ec69-ce1a-45f0-bcf0-7b33845dc53e,lb av,British pound (Avoirdupois),0.45359237,lb,Units of mass
+e5ccc940-eb40-41f9-847e-5ee691ba8c2f,long tn,Long ton,1016.047,tn.lg,Units of mass
+b872a063-0500-42b7-9e5d-441642d84417,mg,Milligram,1.0E-6,,Units of mass
+d022bf34-1162-4579-90ab-dcca9620ce54,Mg,Megagram,1000.0,,Units of mass
+9dd23b40-4394-4f9a-9572-5f2ee9643864,Mt,Megatonne,1.0E9,Mtn,Units of mass
+63214902-17d4-41a0-be10-d1cad375c32e,ng,Nanogram,1.0E-12,,Units of mass
+fa44e424-f37b-419d-8475-723429d63c08,oz av,Ounce (Avoirdupois),0.028349523125,oz,Units of mass
+2457aee5-c7ee-4416-a65a-5be4ff2b2976,oz t,Ounce (Troy),0.0311034768,,Units of mass
+68c83ad3-bc5b-414a-81f7-5b47af2c8a23,pg,Picogram,1.0E-15,,Units of mass
+d4922696-9c95-4b5d-a876-425e98276978,sh tn,Short ton,907.18,tn.sh,Units of mass
+83192ffa-5990-490b-a23a-b45ca072db6f,t,Tonne,1000.0,ton,Units of mass
+d01259b2-24c2-46af-a7fe-36dd025ead15,ug,Microgram,1.0E-9,µg,Units of mass
+a40229e6-7275-42e3-a304-23d590044770,kg*km,Kilogram times kilometre,0.001,kgkm,Units of mass*length
+097768e6-0763-4126-a253-e323cafdf77e,kt*km,Kilotonne times kilometre,1000.0,ktkm,Units of mass*length
+5458351a-f6f7-4e0b-a449-823c9b6374db,lb*mi,British pound (Avoirdupois) times international mile,7.2998615E-4,,Units of mass*length
+d24270f0-c1f2-49ec-a6bf-e86a74177070,lb*nmi,British pound (Avoirdupois) times nautical mile,8.40531E-4,,Units of mass*length
+0dea4ed8-bb6b-4049-b2b4-b2c413ef2180,t*km,Metric tonne times kilometre,1.0,tkm;metric ton*km,Units of mass*length
+3cc51ae9-b993-4a3d-964e-0aed8d7f3966,t*mi,Metric tonne times international mile,1.609344,,Units of mass*length
+7dd57df4-c092-41aa-966e-c93a27797ea1,t*nmi,Metric tonne times nautical mile,1.852,,Units of mass*length
+2fdc0039-6c5e-489a-af77-b225684fa337,g*a,Gram times year,0.365,,Units of mass*time
+b2ad404c-3e4f-4a7a-a604-46fb36654823,kg*a,Kilogram times year,365.0,kgy,Units of mass*time
+ab01fe47-d2c0-4308-adb1-e32df38d5a50,kg*d,Kilogram times day,1.0,kg*day,Units of mass*time
+23cc7a32-f08a-43df-a87c-66953eeeb3f5,t*a,Metric tonne times year,365000.0,,Units of mass*time
+5209be3d-094e-4203-a074-06d7b75e9a38,t*d,Metric tonne times day,1000.0,,Units of mass*time
+653766dc-b4d1-4a62-b0b0-69fe4c4be931,cmol,,0.01,,Units of mole
+807ff448-c8bc-4d1f-b3b6-7c6b8d16eee9,mol,,1.0,,Units of mole
+3bd6c6c3-bb61-46f3-b19a-c87ac5502bb7,Dozen(s),Dozen(s) of items,12.0,dozen,Units of number
+6dabe201-aaac-4509-92f0-d00c26cb72ab,Item(s),Number of items,1.0,unit;LU;pig place;p;item,Units of number
+2abb86b6-e71b-4de5-a766-a20e80e59b6d,Items*km,Item times kilometre,1.0,,Units of number*length
+ce39138f-55f8-47bc-b55a-66027fc836d9,Items*mi,Item times international mile,1.609344,,Units of number*length
+9bf0166c-fa76-47d0-95af-054ea9125f2c,Items*nmi,Item times nautical mile,1.852,,Units of number*length
+885f4273-ff04-46b1-a1d7-03c712dffa41,v*km,Vehicle times kilometre,1.0,vkm,Units of number*length
+fe8da65d-f0ea-4496-b13e-1955aaa412d7,p*km,Person times kilometre,1.0,pkm;personkm;person*km,Units of person*length
+702d94e7-fbae-4a99-a2f5-b26db21126d6,p*mi,Person times international mile,1.609344,pmi,Units of person*length
+5dc11308-c00e-4c91-8d8d-8a458a5ea968,guest night,Person times day,1.0,,Units of person*time
+c1045008-343e-43e0-8e6d-32eb48bf3f59,GW,Gigawatt,1.0E9,GWp,Units of power
+944d227c-c7cf-421a-b54b-277fd77b8f18,kW,Kilowatt,1000.0,kWp,Units of power
+fab62514-4b89-4ef3-9e82-79e4533c2ad9,MW,Megawatt,1000000.0,MWp,Units of power
+8e453491-064d-486f-b043-7d5f6e260364,W,Watt,1.0,Wp,Units of power
+ac324d87-9961-463a-81a1-099bb0f7d89b,Bq,Bequerel,0.001,,Units of radioactivity
+ef6d9358-a156-4c73-b678-320ddee7d2eb,Ci,Curie,3.7E7,,Units of radioactivity
+e9773595-284e-46dd-9671-5fc9ff406833,kBq,Kilobequerel,1.0,,Units of radioactivity
+e2987dad-3b7e-451e-82df-fe91756e752a,mBq,Milibequerel,1.0E-6,,Units of radioactivity
+df1ceca8-2d2a-46fa-91c1-24e5dd0f248f,nBq,Nanobequerel,1.0E-12,,Units of radioactivity
+a45722ee-fc30-4bb1-aa95-5c8fb56c6bfb,Rutherford,Rutherford,1000.0,,Units of radioactivity
+a9736781-d59e-43dc-8584-147b50595c1c,µBq,Microbequerel,1.0E-9,,Units of radioactivity
+9a87f840-752d-4863-b911-533f92ee5073,a,Year,8760.0,year;yr,Units of time
+11074cfd-08a4-449b-adad-18ce24a1b275,d,Day,24.0,day,Units of time
+227a54d9-44e7-468c-b8bb-f2dd1ae68c7a,h,Hour,1.0,hr,Units of time
+9fa94e47-03bd-4ad1-8726-e10cfb6dbb7a,min,Minute,0.01666666666666667,,Units of time
+845178d8-3f2c-497f-9ca6-3c5657c2823c,s,Second,2.777777777777778E-4,,Units of time
+91995a9e-3cb4-4fc9-a93b-8c618ff9b948,bbl,Barrel (Petroleum),0.158987294928,,Units of volume
+9bc2cfb2-fb43-42e6-9783-6c7479c78cce,bl (Imp),Barrel (Imperial),0.158987294928,,Units of volume
+a681e9e5-6304-45f0-a5f4-df413eee0724,bl (US beer),Barrel (US Beer),0.117,,Units of volume
+1c4169d1-4fee-40e3-9868-953ee15e26ae,bl (US dry),Barrel (US Dry),0.1156,,Units of volume
+89121cea-0d98-4466-9b0f-e33e448db7ec,bl (US fl),Barrel (US Non-beer fluid),0.119,,Units of volume
+90888d8d-3d57-497f-a3fa-12aefd2bc774,bsh (Imp),Imperial bushel,0.03636872,,Units of volume
+5ec65531-6bb4-4990-a687-44e9ab8f3529,bsh (US),US bushel,0.03,,Units of volume
+ac4057f9-ec4a-4b31-9d3b-ff96969e50ff,cl,Centilitre,1.0E-5,cL,Units of volume
+46930fb7-8660-42a4-983e-19cf53da740b,cm3,Cubic centimetre,1.0E-6,,Units of volume
+07973a41-56b3-4e1b-a208-fd75a09fbd4b,cu ft,Cubic feet,0.0283168,cuft,Units of volume
+2d895297-8e96-45f1-b256-a6d4ccd4bbc4,dal,Decalitre,0.01,daL,Units of volume
+626c92d5-dcc2-40d4-b28b-4a4f82123740,dl,Decilitre,1.0E-4,dL,Units of volume
+2ea37335-f10b-4fcc-b4a9-0a742d651fa2,dm3,Cubic decimeter,0.001,,Units of volume
+72ef94e2-bf0c-4e85-a74c-f3b5ed1bd73e,dr (Fl),Dram (Fluid),3.6966911953125E-6,,Units of volume
+806c64aa-8609-4ff6-a033-6714a3348f24,fl oz (Imp),Fluid ounce (Imperial),2.841E-5,,Units of volume
+8aa31dda-e324-469c-a29d-56476584f5ca,gal (Imp),Gallon (Imperial),0.00454609,,Units of volume
+c530708d-be50-4207-b536-23d0857210bf,gal (US dry),Gallon (US Dry),0.00440488377086,,Units of volume
+431df202-da83-4baa-b576-5d17f59f0c8a,gal (US fl),Gallon (US Fluid),0.003785411784,,Units of volume
+62eb6f51-0574-4489-ae1a-1bd806f6c2ac,gal (US liq),Gallon (US Liquid),0.003785411784,gal*,Units of volume
+078c7a18-a743-491d-87c2-530454661ef1,gill,Gill,1.18294E-4,,Units of volume
+e24e5e7b-6c5c-4847-969d-7772ed5df017,hl,Hectolitre,0.1,hL,Units of volume
+cff8f1bf-bda0-4fc1-b14c-537d8861dcce,Imp.min.,Minim,5.91938802E-8,,Units of volume
+6a7531d3-3b83-4dda-8b18-4e3528491f9e,in3,Cubic inch,1.63871E-5,cu.in,Units of volume
 b80a512e-e402-4363-8ad0-7d02dcf4a459,l,Litre,0.001,,Units of volume
-8c1fafa2-2b2e-4fef-9581-5de34ae87350,l*a,Litre times year,0.001,,Units of volume*time
-9942703a-5962-4823-8ea3-7af06af9a21e,l*d,Litre times day,2.73787574E-6,l*day,Units of volume*time
+1c3a9695-398d-4b1f-b07e-a8715b610f70,m3,Cubic metre,1.0,m³;kl;kL;Sm3;Nm3,Units of volume
+81696a66-6919-4bbb-a3ab-c79b2900de7d,ml,Millilitre,1.0E-6,mL,Units of volume
+505845e0-3f71-46d4-acfa-8c4ed8d3c305,mm3,Cubic millimetre,1.0E-9,,Units of volume
+7642bdc2-cdfa-4cc5-9e12-2255f561842a,pk,Peck,0.008809768,,Units of volume
+c026770b-5b4f-467d-8fdb-15dfb8e52913,pt (Imp),Pint (Imperial),5.6826125E-4,,Units of volume
+a19bcd84-e836-4764-8367-419dac3d2434,pt (US dry),Pint (US Dry),5.506E-4,,Units of volume
+2df86f1f-293e-4e07-9cde-34eebc6d2c5f,pt (US fl),Pint (US Fluid),4.73E-4,,Units of volume
+08d8bee4-32ca-4cc3-ad33-838377e6517a,qt (US dry),Quart (US Dry),0.00110121,,Units of volume
+fea33583-ae83-4398-b7fb-7f90fd097269,qt (US liq),Quart (US Liquid),9.46353E-4,,Units of volume
+df6987d7-afcc-4c92-ae2c-3ce3bc6f5578,ul,Microlitre,1.0E-9,µl;µL,Units of volume
+2d64c7e0-1167-42ec-9988-c441c261a35c,US fl oz,US customary fluid ounce,2.95735295625E-5,,Units of volume
+9cd2a2c5-77a2-4b58-b893-b039dfe635ed,yd3,Cubic yards,0.76455485798,cu.yd,Units of volume
 a0805221-ed1e-4177-9e2a-4b72ce2beb06,l*km,Litre times kilometre,0.001,,Units of volume*length
 112e9d4a-262d-4dcb-8003-c19204faedfb,l*mi,Litre times international mile,0.001609344,,Units of volume*length
 0c62f887-da22-4b0a-999b-145c4b2ffe1e,l*nmi,Litre times nautical mile,0.001852,,Units of volume*length
-0300ec69-ce1a-45f0-bcf0-7b33845dc53e,lb av,British pound (avoirdupois),0.45359237,lb,Units of mass
-5458351a-f6f7-4e0b-a449-823c9b6374db,lb*mi,British pound (avoirdupois) times international mile,7.2998615E-4,,Units of mass*length
-d24270f0-c1f2-49ec-a6bf-e86a74177070,lb*nmi,British pound (avoirdupois) times nautical mile,8.40531E-4,,Units of mass*length
-e5ccc940-eb40-41f9-847e-5ee691ba8c2f,long tn,Long ton,1016.047,tn.lg,Units of mass
-3d314eab-ef11-4ff3-a35e-9bc5cd858694,m,Metre,1.0,,Units of length
-f7fe0af2-e764-4984-bb9f-2cbff6cd2f18,m*a,Metre times year,1.0,ma;my,Units of length*time
-3ce61faa-5716-41c1-aef6-b5920054acc9,m2,Square metre,1.0,m²,Units of area
-c7266b67-4ea2-457f-b391-9b94e26e195a,m2*a,Square metre times year,1.0,m²*a;m2a;m²a;m2*year,Units of area*time
-00d8370e-2bf1-4f3b-81bb-f8f147e84819,m2*d,Square metre times day,0.00273790933,,Units of area*time
-1c3a9695-398d-4b1f-b07e-a8715b610f70,m3,Cubic metre,1.0,m³; kl;kL,Units of volume
-ee5f2241-18af-4444-b457-b275660e5a20,m3*a,Cubic metre times year,1.0,m³*a;m3a;m3y,Units of volume*time
-f3a1ae74-9750-4199-acdc-2e7e0546e0a5,m3*d,Cubic metre times day,0.00273787,m³*d;m3d;m3day,Units of volume*time
 5042a5e9-b8fd-40ca-b13e-cb9f1ce0357a,m3*km,Cubic metre times kilometre,1.0,,Units of volume*length
 de900fea-2536-4fe5-a92d-00ac9a28654b,m3*mi,Cubic metre times international mile,1.609344,,Units of volume*length
 fad23f5c-f841-4369-ba17-2dd297b5fadf,m3*nmi,Cubic metre times nautical mile,1.852,,Units of volume*length
-e2987dad-3b7e-451e-82df-fe91756e752a,mBq,miliBequerel,1.0E-6,,Units of radioactivity
-b872a063-0500-42b7-9e5d-441642d84417,mg,Milligram,1.0E-6,,Units of mass
-4a51d52b-f94f-4168-a38c-c612f14b8a2d,mi,International mile,1609.344,mile,Units of length
-7d082bce-60f5-4588-86bb-56e0dff1c8a8,mi*a,Miles * year,1609.344,miy,Units of length*time
-20ce5f57-69b1-438b-a8e8-23089854d058,mi2,British square mile,2589988.11,mi²;sq.mi,Units of area
-1c43f336-c84b-4f42-bbf7-b1b6f89e121a,mi2*a,British square mile times year,2589988.11,mi²*a;mi2a;mi²a,Units of area*time
-9fa94e47-03bd-4ad1-8726-e10cfb6dbb7a,min,Minute,6.9444E-4,,Units of time
-81696a66-6919-4bbb-a3ab-c79b2900de7d,ml,Millilitre,1.0E-6,mL,Units of volume
-cc44768b-c0ce-4bc9-804a-c59b67d22e39,mm,Millimetre,0.001,,Units of length
-0dc79b8e-47a1-4ec7-96b1-c9b9da2769fa,mm*m2,Millimetre times square metre,1.0,,Units of length*area
-0992b8e3-489a-46ea-8d71-1bf951ece5d0,mm2,Square millimetres,1.0E-6,,Units of area
-b396b97c-29ab-409a-b6fa-2285589041bd,mm2a,Square millimetres * year,1.0E-6,,Units of area*time
-505845e0-3f71-46d4-acfa-8c4ed8d3c305,mm3,Cubic millimetres,1.0E-9,,Units of volume
-df1ceca8-2d2a-46fa-91c1-24e5dd0f248f,nBq,nanoBequerel,1.0E-12,,Units of radioactivity
-63214902-17d4-41a0-be10-d1cad375c32e,ng,Nanogram,1.0E-12,,Units of mass
-1f112940-6c27-4c75-828a-46d548d71cff,nmi,Nautical mile,1852.0,,Units of length
-4689d28c-29f6-4f0a-ad03-0276f7070edd,nmi2,Square nautical mile,3429904.0,,Units of area
-fa44e424-f37b-419d-8475-723429d63c08,oz av,"Ounce (avoirdupois); commonly used, but NOT for gold, platinum etc. (see Ounce (troy))",0.028349523125,oz,Units of mass
-2457aee5-c7ee-4416-a65a-5be4ff2b2976,oz t,Ounce (troy),0.0311034768,,Units of mass
-fe8da65d-f0ea-4496-b13e-1955aaa412d7,p*km,Person kilometre,1.0,pkm;personkm,Units of person transport
-702d94e7-fbae-4a99-a2f5-b26db21126d6,p*mi,Person * mile,1.609344,pmi,Units of person transport
-68c83ad3-bc5b-414a-81f7-5b47af2c8a23,pg,Picogram; 10^-12 g,1.0E-15,,Units of mass
-7642bdc2-cdfa-4cc5-9e12-2255f561842a,pk,Peck,0.008809768,,Units of volume
-c026770b-5b4f-467d-8fdb-15dfb8e52913,pt (Imp),Pint (Imperial),5.6826125E-4,,Units of volume
-a19bcd84-e836-4764-8367-419dac3d2434,pt (US dry),Pint (US dry),5.506E-4,,Units of volume
-2df86f1f-293e-4e07-9cde-34eebc6d2c5f,pt (US fl),Pint (US fluid),4.73E-4,,Units of volume
-08d8bee4-32ca-4cc3-ad33-838377e6517a,qt (US dry),Quart (US dry),0.00110121,,Units of volume
-fea33583-ae83-4398-b7fb-7f90fd097269,qt (US liq),Quart (US liquid),9.46353E-4,,Units of volume
-845178d8-3f2c-497f-9ca6-3c5657c2823c,s,Second,1.157407E-5,,Units of time
-d4922696-9c95-4b5d-a876-425e98276978,sh tn,Short ton,907.18,tn.sh,Units of mass
-83192ffa-5990-490b-a23a-b45ca072db6f,t,Tonne,1000.0,ton,Units of mass
-23cc7a32-f08a-43df-a87c-66953eeeb3f5,t*a,Metric tonnes times year,1000.0,,Units of mass*time
-5209be3d-094e-4203-a074-06d7b75e9a38,t*d,Metric tonne times day (1 year = 365 days),2.7397,,Units of mass*time
-0dea4ed8-bb6b-4049-b2b4-b2c413ef2180,t*km,Metric tonne-kilometre,1.0,tkm,Units of mass*length
-3cc51ae9-b993-4a3d-964e-0aed8d7f3966,t*mi,Metric tonne times international mile,1.609344,,Units of mass*length
-7dd57df4-c092-41aa-966e-c93a27797ea1,t*nmi,Metric tonne times nautical mile,1.852,,Units of mass*length
-9003179a-bf17-4e89-8fd7-a0c1c91ac189,u,Micron,1.0E-6,µm;um,Units of length
-d01259b2-24c2-46af-a7fe-36dd025ead15,ug,Microgram,1.0E-9,µg,Units of mass
-df6987d7-afcc-4c92-ae2c-3ce3bc6f5578,ul,Microlitre,1.0E-9,µl;µL,Units of volume
-19a89180-e40c-4f6b-bcd3-d7347566d1e7,v*km,Vehicle-kilometer,1.0,vkm,Units of vehicle transport
-a16960ba-31e2-4fe9-82fe-219013f4708f,yd,Yard (international),0.9144,yard,Units of length
-6c4b1e4a-bf45-4385-a60c-12cc48ecbab5,yd2,Square yard (imperial/US),0.836127,sq.yd,Units of area
-9cd2a2c5-77a2-4b58-b893-b039dfe635ed,yd3,Cubic yards,0.76455485798,cu.yd,Units of volume
-a9736781-d59e-43dc-8584-147b50595c1c,µBq,microBequerel,1.0E-9,,Units of radioactivity
+9e6a97bb-e0cf-4e4a-9f3a-37067740b421,cm3*a,Cubic centimetre times year,9.999999999999997E-7,cm3y,Units of volume*time
+8c1fafa2-2b2e-4fef-9581-5de34ae87350,l*a,Litre times year,0.001,,Units of volume*time
+9942703a-5962-4823-8ea3-7af06af9a21e,l*d,Litre times day,2.7397260273972604E-6,l*day,Units of volume*time
+ee5f2241-18af-4444-b457-b275660e5a20,m3*a,Cubic metre times year,1.0,m³*a;m3a;m3y;m3*year,Units of volume*time
+f3a1ae74-9750-4199-acdc-2e7e0546e0a5,m3*d,Cubic metre times day,0.00273972602739726,m³*d;m3d;m3day,Units of volume*time


### PR DESCRIPTION
No UUIDs are changed, only deleted completely or added. No Unit names are changed, only deleted or added. 

Old Gabi flow properties, unit groups and units for "Erosion Resistance (Occ.) or "Groundwater Replenishment (Transf.) and others are removed. 

"Vehicle transport" is removed and the unit v*km is merged with "Item transport" and "Units of number*length" because it is the same.

"Energy/area*time" with "Units of energy/area*time" is removed, since the origin is unknown, it only contains one single unit and it is a very rare and untypical flow property and the naming is wrong because it should be "Energy/(Area*Time)" or "Energy/Area/Time".

"Energy/mass*time" with "Units of energy/mass*time" is removed, since the origin is unknown, it only contains one single unit and it is a very rare and untypical flow property. Most likely as for "Energy/area*time" the brackets in the denominator should be set in the name because otherwise it would be a different unit.

"Mole" / "Units of mole" is added.
"Power" / "Units of power" is added.
"Guest night" / "Units of person*time" is added.

"Duration" flow property renamed to "Time".
"Number of items" flow property is renamed to "Number".
"Item*Length" flow property is renamed to "Item transport".
"Goods transport (mass*distance)" flow property is renamed to "Mass transport".
"Volume*Length" flow property is renamed to "Volume transport".

Names of unit groups are changed to the actual name of the quantities involved, e.g. "Units of person*length", "Units of number*length" and Units of "person*time", whereas the flow properties can have different names like "Item transport" or "Guest night".

Descriptions are written more clean and neat.

Corrected and cleaned locations
- no special characters inside the names
- if special characters are used in the local name together with the international name, it should be put in brackets after the international name, like "China, Shaanxi (陕西)"
- locations in Country follow ISO 3166-1 names and ISO 3166-1 codes, if not existing they are sorted into "Miscellaneous"
- locations in Subdivision follow ISO 3166-2 codes, if not existing they are sorted into "Miscellaneous"
- locations in Subdivision follow ISO 3166-2 codes with the corresponding ISO 3166-1 country name placed in front like "Unites States of America, California"
- "Unlocated" folder is only used for locations without a fixed geometry like GLO or a variable, not always similar defined geometry like RoE, RoW
- Electricity contains the electricity grids with the corresponding ISO 3166-1 country names in front
- Cutout regions get the same code as the name, because a created code would be too long and not useful (no code naming appears in openLCA in the navigation pane)
- Aluminium regions get the same code as the name, because there is no need for a code and no common sense for a code (no code naming appears in openLCA in the navigation pane)